### PR TITLE
AI/Cyborgs no longer need to directly click the door sprite to interact with it.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -107,10 +107,25 @@
 
 /mob/living/silicon/ai/CtrlShiftClickOn(var/atom/A)
 	A.AICtrlShiftClick(src)
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+	if(airlock)
+		airlock.AICtrlShiftClick(src)
+	return // End of skyrat edit
+
 /mob/living/silicon/ai/ShiftClickOn(var/atom/A)
 	A.AIShiftClick(src)
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+	if(airlock)
+		airlock.AIShiftClick(src)
+	return // End of skyrat edit 
+
 /mob/living/silicon/ai/CtrlClickOn(var/atom/A)
 	A.AICtrlClick(src)
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A    // Skyrat edit 
+	if(airlock)                              
+		airlock.AICtrlClick(src)
+	return // End of skyrat edit
+
 /mob/living/silicon/ai/AltClickOn(var/atom/A)
 	if(!A.AIAltClick(src))
 		altclick_listed_turf(A)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -93,10 +93,26 @@
 // for non-doors/apcs
 /mob/living/silicon/robot/CtrlShiftClickOn(atom/A)
 	A.BorgCtrlShiftClick(src)
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+	if(airlock)
+		airlock.AICtrlShiftClick(src)
+	return // End of skyrat edit
+
 /mob/living/silicon/robot/ShiftClickOn(atom/A)
 	A.BorgShiftClick(src)
+	A.AIShiftClick(src)
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+	if(airlock)
+		airlock.AIShiftClick(src)
+	return // End of skyrat edit
+
 /mob/living/silicon/robot/CtrlClickOn(atom/A)
 	A.BorgCtrlClick(src)
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+	if(airlock)
+		airlock.AICtrlClick(src)
+	return // End of skyrat edit
+
 /mob/living/silicon/robot/AltClickOn(atom/A)
 	if(!A.BorgAltClick(src))
 		altclick_listed_turf(A)


### PR DESCRIPTION
About The Pull Request
AI/Cyborgs no longer have to directly press the sprite of the door to use their shortcut bolt/close/emergency acces
Thanks to Bob Joga for helping with the code.

Why It's Good For The Game
QoL for any AI/Cyborg player , there is no longer a need to shift the mouse a few pixels to close a door

Changelog
🆑
add:AI/Cyborgs no longer are required to click the door sprite to close/bolt/emergency acces them.
/🆑

Porting: https://github.com/Skyrat-SS13/Skyrat13/pull/3484