### PR TITLE
More spaceship beacon fixes

### DIFF
--- a/html/changelogs/SandPoot brute force copy 2.yml
+++ b/html/changelogs/SandPoot brute force copy 2.yml
@@ -1,0 +1,4 @@
+author: "SandPoot"
+delete-after: True
+changes: 
+  - fix: "Finally 100% fixes beacons, you can now build beacons and go to that Z-level on your custom shuttle (or whiteship i guess)."

--- a/sandcode/code/modules/shuttle/spaceship_navigation_beacon.dm
+++ b/sandcode/code/modules/shuttle/spaceship_navigation_beacon.dm
@@ -22,16 +22,18 @@
 /obj/machinery/spaceship_navigation_beacon/Initialize()
 	. = ..()
 	SSshuttle.beacons |= src
-	for(var/obj/machinery/computer/camera_advanced/shuttle_docker/console in world)
-		console.z_lock |= src.z
+	for(var/V in GLOB.navigation_computers)
+		var/obj/machinery/computer/camera_advanced/shuttle_docker/C = V
+		C.z_lock |= src.z
 
-obj/machinery/spaceship_navigation_beacon/emp_act()
+/obj/machinery/spaceship_navigation_beacon/emp_act()
 	locked = TRUE
 
 /obj/machinery/spaceship_navigation_beacon/Destroy()
 	SSshuttle.beacons -= src
-	for(var/obj/machinery/computer/camera_advanced/shuttle_docker/console in world)
-		console.z_lock -= src.z
+	for(var/V in GLOB.navigation_computers)
+		var/obj/machinery/computer/camera_advanced/shuttle_docker/C = V
+		C.z_lock -= src.z
 	return ..()
 
 // update the icon_state

--- a/sandcode/code/modules/shuttle/spaceship_navigation_beacon.dm
+++ b/sandcode/code/modules/shuttle/spaceship_navigation_beacon.dm
@@ -22,12 +22,16 @@
 /obj/machinery/spaceship_navigation_beacon/Initialize()
 	. = ..()
 	SSshuttle.beacons |= src
+	for(var/obj/machinery/computer/camera_advanced/shuttle_docker/console in world)
+		console.z_lock |= src.z
 
 obj/machinery/spaceship_navigation_beacon/emp_act()
 	locked = TRUE
 
 /obj/machinery/spaceship_navigation_beacon/Destroy()
 	SSshuttle.beacons -= src
+	for(var/obj/machinery/computer/camera_advanced/shuttle_docker/console in world)
+		console.z_lock -= src.z
 	return ..()
 
 // update the icon_state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
On the fix prior to this, shuttles could not move anywhere without a z-lock allowing then, thus this will make so that built beacons will add their Z to all custom shuttle computers.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Finally 100% fixes beacons, you can now build beacons and go to that Z-level on your custom shuttle (or whiteship i guess).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
