### PR TITLE
Plating changes

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -101,6 +101,15 @@
 					to_chat(user, "<span class='notice'>You add reinforced glass to the floor.</span>")
 				return
 	else if(istype(C, /obj/item/stack/tile))
+		//sandstorm edit
+		if(istype(src, /turf/open/floor/plating/asteroid))
+			var/obj/item/stack/tile/plasteel/W = C
+			if(!W.use(1))
+				return
+			ChangeTurf(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+			playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
+			return
+		//sandstorm edit
 		if(!broken && !burnt)
 			for(var/obj/O in src)
 				if(O.level == 1) //ex. pipes laid underneath a tile

--- a/sandcode/code/game/turfs/simulated/floor/plating.dm
+++ b/sandcode/code/game/turfs/simulated/floor/plating.dm
@@ -1,0 +1,24 @@
+/turf/open/floor/plating
+	var/unfastened = FALSE
+
+/turf/open/floor/plating/screwdriver_act(mob/living/user, obj/item/I)
+	if(src.type == /turf/open/floor/plating)
+		to_chat(user, "<span class='notice'>You start [unfastened ? "fastening" : "unfastening"] [src].</span>")
+		if(!I.use_tool(src, user, 20, volume = 80))
+			return
+		to_chat(user, "<span class='notice'>You [unfastened ? "fasten" : "unfasten"] [src].</span>")
+		unfastened = !unfastened
+
+/turf/open/floor/plating/welder_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(src.type == /turf/open/floor/plating && unfastened)
+		if(baseturfs == /turf/baseturf_bottom || istype(baseturfs, /turf/open/space))
+			to_chat(user, "<span class='warning'>You start removing [src], exposing space after you're done!</span>")
+			if(!I.use_tool(src, user, 50, volume = 160)) //extra loud to let people know something's going down
+				return
+			new /obj/item/stack/tile/plasteel(get_turf(src))
+			ReplaceWithLattice()
+			return
+		else
+			to_chat(user, "<span class='warning'>You cannot remove this plating.</span>")
+			return

--- a/sandcode/code/game/turfs/simulated/floor/plating.dm
+++ b/sandcode/code/game/turfs/simulated/floor/plating.dm
@@ -1,13 +1,27 @@
 /turf/open/floor/plating
 	var/unfastened = FALSE
 
+/turf/open/floor/plating/examine(mob/user)
+	. = ..()
+	if(!(baseturfs == /turf/baseturf_bottom || istype(baseturfs, /turf/open/space)))
+		. += "<span class='notice'>\The [src] cannot be removed from the floor.</span>"
+	else if(unfastened)
+		. += "<span class='notice'>\The [src] could be <b>welded</b> off the floor.</span>"
+		. += "<span class='warning'>The screws on [src] appear loose.</span>"
+	else
+		. += "<span class='notice'>The screws on [src] could be loosened with <b>a screwdriver</b>.</span>"
+
 /turf/open/floor/plating/screwdriver_act(mob/living/user, obj/item/I)
 	if(src.type == /turf/open/floor/plating)
-		to_chat(user, "<span class='notice'>You start [unfastened ? "fastening" : "unfastening"] [src].</span>")
-		if(!I.use_tool(src, user, 20, volume = 80))
+		if(baseturfs == /turf/baseturf_bottom || istype(baseturfs, /turf/open/space))
+			to_chat(user, "<span class='notice'>You start [unfastened ? "fastening" : "unfastening"] [src].</span>")
+			if(!I.use_tool(src, user, 20, volume = 80))
+				return
+			to_chat(user, "<span class='notice'>You [unfastened ? "fasten" : "unfasten"] [src].</span>")
+			unfastened = !unfastened
+		else
+			to_chat(user, "<span class='warning'>You cannot remove this plating.</span>")
 			return
-		to_chat(user, "<span class='notice'>You [unfastened ? "fasten" : "unfasten"] [src].</span>")
-		unfastened = !unfastened
 
 /turf/open/floor/plating/welder_act(mob/living/user, obj/item/I)
 	. = ..()
@@ -20,5 +34,4 @@
 			ReplaceWithLattice()
 			return
 		else
-			to_chat(user, "<span class='warning'>You cannot remove this plating.</span>")
 			return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3707,6 +3707,7 @@
 #include "sandcode\code\game\objects\structures\ladders.dm"
 #include "sandcode\code\game\objects\structures\lavaland\necropolis_tendril.dm"
 #include "sandcode\code\game\turfs\simulated\floor\asteroid.dm"
+#include "sandcode\code\game\turfs\simulated\floor\plating.dm"
 #include "sandcode\code\modules\admin\verbs\fix_air.dm"
 #include "sandcode\code\modules\atmospherics\machinery\pipes\bluespace.dm"
 #include "sandcode\code\modules\cargo\packs\emergency.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows you to place plating instead of a regular tile on asteroid tiles and platings on the station can be removed, revealing a hole to space.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is important, and helps with some stuff. (It's hard to build a base on lavaland when the floor there is basically a scrubber on siphon and sometimes floors need to be completely removed!)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
A bit, uses some stuff from https://github.com/Lumos-SS13/Lumos/commit/b46f2d07532f7d3f7cd2a3f8e49221d2e539f9c9 and https://github.com/ParadiseSS13/Paradise/commit/fddff1049b970872dd539eb5b9ebc6a434b8e301(paradise is a shrug, this is probably very old).
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
add: Platings can be removed from the floor (currently only certain ones), just examine it to know if you can or not, and how to.
tweak: Trying to place a tile on an asteroid turf, such as lavaland's, will no longer place a regular tile and instead place plating first.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
