### PR TITLE
Fixes decal painter radial previews

### DIFF
--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -134,7 +134,7 @@
 	icon_state = "decal_sprayer"
 	item_state = "decalsprayer"
 	custom_materials = list(/datum/material/iron=2000, /datum/material/glass=500)
-	var/stored_dir = 2
+	var/stored_dir = 1
 	var/stored_color = ""
 	var/stored_decal = "warningline"
 	var/stored_decal_total = "warningline"
@@ -169,9 +169,9 @@
 /obj/item/airlock_painter/decal/AltClick(mob/user) //sandstorm change - everything that makes this work is on same path to this but on sandcode
 	. = ..()
 	var/decal_category = list(
-		"Decal" = image(icon = 'icons/turf/decals.dmi', icon_state = "[stored_decal]", dir = stored_dir),
+		"Decal" = image(icon = 'icons/turf/decals.dmi', icon_state = "[stored_decal]", dir = turn(stored_dir, 180)),
 		"Color" = image(icon = 'icons/obj/crayons.dmi', icon_state = "crayonred"),
-		"Dir" = image(icon = 'icons/obj/device.dmi', icon_state = "pinonfar", dir = stored_dir)
+		"Dir" = image(icon = 'icons/obj/device.dmi', icon_state = "pinonfar", dir = turn(stored_dir, 180))
 	)
 	var/cat_chosen = show_radial_menu(user,src,decal_category, custom_check = CALLBACK(src,.proc/check_menu,user), require_near = TRUE, tooltips = TRUE)
 	if(!check_menu(user))

--- a/sandcode/code/game/objects/items/airlock_painter.dm
+++ b/sandcode/code/game/objects/items/airlock_painter.dm
@@ -18,7 +18,7 @@
 		"Delivery Marker" = image(icon = 'icons/turf/decals.dmi', icon_state = "delivery", dir = stored_dir),
 		"Warning Box" = image(icon = 'icons/turf/decals.dmi', icon_state = "warn_full", dir = stored_dir)
 	)
-	var/choice = show_radial_menu(user,src,decal_list_img, custom_check = CALLBACK(src,.proc/check_menu,user), require_near = TRUE, tooltips = TRUE)
+	var/choice = show_radial_menu(user, src, decal_list_img, radius = 45, custom_check = CALLBACK(src,.proc/check_menu,user), require_near = TRUE, tooltips = TRUE)
 	if(!check_menu(user))
 		return
 	switch(choice)
@@ -85,7 +85,7 @@
 		"Red" = image(icon = 'icons/obj/crayons.dmi', icon_state = "crayonred"),
 		"White" = image(icon = 'icons/obj/crayons.dmi', icon_state = "crayonwhite")
 	)
-	var/choice = show_radial_menu(user,src,choose_color, custom_check = CALLBACK(src,.proc/check_menu,user), require_near = TRUE, tooltips = TRUE)
+	var/choice = show_radial_menu(user, src, choose_color, custom_check = CALLBACK(src,.proc/check_menu,user), require_near = TRUE, tooltips = TRUE)
 	if(!check_menu(user))
 		return
 	switch(choice)
@@ -118,22 +118,22 @@
 	if(!check_menu(user))
 		return
 	switch(choice)
-		if("North")
+		if("South")
 			stored_dir = dir_list[1]
 			playsound(src, 'sound/effects/pop.ogg', 50, 0)
 			to_chat(user, "<span class='notice'>You change [src] direction to '[choice]'.</span>")
 			update_decal_path()
-		if("South")
+		if("North")
 			stored_dir = dir_list[2]
 			playsound(src, 'sound/effects/pop.ogg', 50, 0)
 			to_chat(user, "<span class='notice'>You change [src] direction to '[choice]'.</span>")
 			update_decal_path()
-		if("East")
+		if("West")
 			stored_dir = dir_list[3]
 			playsound(src, 'sound/effects/pop.ogg', 50, 0)
 			to_chat(user, "<span class='notice'>You change [src] direction to '[choice]'.</span>")
 			update_decal_path()
-		if("West")
+		if("East")
 			stored_dir = dir_list[4]
 			playsound(src, 'sound/effects/pop.ogg', 50, 0)
 			to_chat(user, "<span class='notice'>You change [src] direction to '[choice]'.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title and also increases the radius of the menu that's full of options, the sprites were not so cozy like that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
tweak: The radial type selection for the decal painter now has a bigger radius, so that no sprites go over each other.
fix: Decal painter previews now appear the right way.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
