### PR TITLE
Telecryo fix

### DIFF
--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 	var/newhead = "%PERSON, %RANK, is the department head."
 	var/newheadToggle = TRUE
 	var/cryostorage = "%PERSON, %RANK, has been moved into cryogenic storage." // this shouldnt be changed
+	var/cryostorage_tele = "%PERSON, %RANK, has been teleported to CentCom."   // you saying it hat man.
 
 	var/greenlight = "Light_Green"
 	var/pinklight = "Light_Pink"
@@ -87,6 +88,8 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 		message = CompileText(newhead, user, rank)
 	else if(message_type == "CRYOSTORAGE")
 		message = CompileText(cryostorage, user, rank)
+	else if(message_type == "CRYOSTORAGE_TELE")
+		message = CompileText(cryostorage_tele, user, rank)
 	else if(message_type == "ARRIVALS_BROKEN")
 		message = "The arrivals shuttle has been damaged. Docking for repairs..."
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -295,7 +295,7 @@
 
 			if(tele)
 				despawn_occupant()
-				do_sparks(2, TRUE, src)
+				do_fake_sparks(2, TRUE, src)
 				playsound(src, 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
 
 #define CRYO_DESTROY 0
@@ -421,7 +421,7 @@
 
 	if(GLOB.announcement_systems.len)
 		var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
-		announcer.announce("CRYOSTORAGE", mob_occupant.real_name, announce_rank, list())
+		announcer.announce("[tele ? "CRYOSTORAGE_TELE" : "CRYOSTORAGE"]", mob_occupant.real_name, announce_rank, list())
 		visible_message("<span class='notice'>\The [src] hums and hisses as it [tele ? "teleports" : "moves"] [mob_occupant.real_name] [tele ? "to centcom" : "into storage"].</span>")
 
 	// Ghost and delete the mob.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hart's fix for the cryopods absolutely deprecates `on_store`, this makes sure the "cryo tele" still works and shows the proper message.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
fix: The teleporter no longer "cryos" you (it will display the correct message on radio).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
