### PR TITLE
Adds new items to biobag whitelist

### DIFF
--- a/sandcode/code/game/objects/items/storage/bags.dm
+++ b/sandcode/code/game/objects/items/storage/bags.dm
@@ -1,0 +1,5 @@
+
+/obj/item/storage/bag/bio/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.can_hold_extra = typecacheof(list(/obj/item/reagent_containers/dropper, /obj/item/slimecross/stabilized))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3730,6 +3730,7 @@
 #include "sandcode\code\game\objects\items\stacks\tiles\tile_types.dm"
 #include "sandcode\code\game\objects\items\stacks\tiles\tile_wooden.dm"
 #include "sandcode\code\game\objects\items\storage\backpack.dm"
+#include "sandcode\code\game\objects\items\storage\bags.dm"
 #include "sandcode\code\game\objects\items\tanks\tank_types.dm"
 #include "sandcode\code\game\objects\items\tanks\tanks.dm"
 #include "sandcode\code\game\objects\items\tools\crowbar.dm"


### PR DESCRIPTION
## About The Pull Request

Adds dropper and stabilized slime extracts

## Why It's Good For The Game

Efficiency in xenobio, and storage for anyone who uses stabilized cores

## A Port?

Nope

## Changelog
:cl:
add: Droppers to biobag white list
add: Stabilized slime cores to biobags white list
/:cl:
