### PR TITLE
Puts a golem vendor board in every liberators legacy

### DIFF
--- a/sandcode/code/game/objects/items/storage/boxes.dm
+++ b/sandcode/code/game/objects/items/storage/boxes.dm
@@ -1,0 +1,3 @@
+/obj/item/storage/box/rndboards/PopulateContents()
+	. = ..()
+	new /obj/item/circuitboard/machine/mining_equipment_vendor/golem(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3731,6 +3731,7 @@
 #include "sandcode\code\game\objects\items\stacks\tiles\tile_wooden.dm"
 #include "sandcode\code\game\objects\items\storage\backpack.dm"
 #include "sandcode\code\game\objects\items\storage\bags.dm"
+#include "sandcode\code\game\objects\items\storage\boxes.dm"
 #include "sandcode\code\game\objects\items\tanks\tank_types.dm"
 #include "sandcode\code\game\objects\items\tanks\tanks.dm"
 #include "sandcode\code\game\objects\items\tools\crowbar.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
stealing is bad? maybe.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Yes, https://github.com/Citadel-Station-13/Citadel-Station-13/pull/13868.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl: Hatterhat
add: Apparently someone started shoving golem vendor boards into every liberator's legacy. How odd!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
