### PR TITLE
Hypnotic stupor tweaks and Hypnosis regex fix

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -83,6 +83,16 @@
 
 /datum/config_entry/flag/enable_dogborg_sleepers	// enable normal dogborg sleepers (otherwise recreational)
 
+/datum/config_entry/flag/limit_stupor_trances	// enable limits to hypnotic stupor
+
+/datum/config_entry/number/min_stupor_hypno_duration	//Minimum random duration to maintain hypnosis from hypnotic stupor
+	config_entry_value = 6000
+	min_val = 10
+	
+/datum/config_entry/number/max_stupor_hypno_duration	//Maximum random duration to maintain hypnosis from hypnotic stupor
+	config_entry_value = 12000
+	min_val = 10
+
 /datum/config_entry/flag/economy	//money money money money money money money money money money money money
 
 /datum/config_entry/number/minimum_secborg_alert	//Minimum alert level for secborgs to be chosen.

--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -20,7 +20,7 @@
 		to_chat(usr, "<span class='danger'>Hypnosis New() skipped due to try/catch incompatibility with admin proccalling.</span>")
 		qdel(src)
 	try
-		target_phrase = new("(\\b[hypnotic_phrase]\\b)","ig")
+		target_phrase = new("(\\b[REGEX_QUOTE(hypnotic_phrase)]\\b)","ig")
 	catch(var/exception/e)
 		stack_trace("[e] on [e.file]:[e.line]")
 		qdel(src)

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -262,6 +262,15 @@
 	scan_desc = "oneiric feedback loop"
 	gain_text = "<span class='warning'>You feel somewhat dazed.</span>"
 	lose_text = "<span class='notice'>You feel like a fog was lifted from your mind.</span>"
+	var/min_hypno_duration = 6000
+	var/max_hypno_duration = 12000
+	var/hypno_duration = -1 // 0 or some world time limits, whereas -1 has old behavior
+	
+/datum/brain_trauma/severe/hypnotic_stupor/on_gain()
+	..()
+	min_hypno_duration = CONFIG_GET(number/min_stupor_hypno_duration) // 6000
+	max_hypno_duration = CONFIG_GET(number/max_stupor_hypno_duration) // 12000
+	hypno_duration = CONFIG_GET(flag/limit_stupor_trances) ? 0 : -1
 
 /datum/brain_trauma/severe/hypnotic_stupor/on_lose() //hypnosis must be cleared separately, but brain surgery should get rid of both anyway
 	..()
@@ -270,7 +279,12 @@
 /datum/brain_trauma/severe/hypnotic_stupor/on_life()
 	..()
 	if(prob(1) && !owner.has_status_effect(/datum/status_effect/trance))
-		owner.apply_status_effect(/datum/status_effect/trance, rand(100,300), FALSE)
+		if (world.time > hypno_duration) // Only re-trance every so often
+			owner.apply_status_effect(/datum/status_effect/trance, rand(100,300), FALSE, hypno_duration > -1)
+			
+/datum/brain_trauma/severe/hypnotic_stupor/proc/on_hypnosis()
+	if (hypno_duration > -1)
+		hypno_duration = world.time + rand(min_hypno_duration, max_hypno_duration)
 
 /datum/brain_trauma/severe/hypnotic_trigger
 	name = "Hypnotic Trigger"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -913,6 +913,7 @@ datum/status_effect/pacify
 	duration = 300
 	tick_interval = 10
 	examine_text = "<span class='warning'>SUBJECTPRONOUN seems slow and unfocused.</span>"
+	var/is_stupor = FALSE
 	var/stun = TRUE
 	alert_type = /obj/screen/alert/status_effect/trance
 
@@ -937,9 +938,10 @@ datum/status_effect/pacify
 	"<span class='warning'>[pick("You feel your thoughts slow down...", "You suddenly feel extremely dizzy...", "You feel like you're in the middle of a dream...","You feel incredibly relaxed...")]</span>")
 	return TRUE
 
-/datum/status_effect/trance/on_creation(mob/living/new_owner, _duration, _stun = TRUE)
+/datum/status_effect/trance/on_creation(mob/living/new_owner, _duration, _stun = TRUE, _is_stupor = FALSE)
 	duration = _duration
 	stun = _stun
+	is_stupor = _is_stupor
 	return ..()
 
 /datum/status_effect/trance/on_remove()
@@ -956,6 +958,14 @@ datum/status_effect/pacify
 	if(hearing_args[HEARING_SPEAKER] == owner)
 		return
 	var/mob/living/carbon/C = owner
+	if (is_stupor) // Record when a hypnosis is applied
+		var/mob/living/carbon/human/H = owner
+		var/list/traumas = H.get_traumas()
+		for(var/X in traumas)
+			var/datum/brain_trauma/BT = X
+			if (istype(BT, /datum/brain_trauma/severe/hypnotic_stupor))
+				var/datum/brain_trauma/severe/hypnotic_stupor/T = BT
+				T.on_hypnosis()
 	C.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY) //clear previous hypnosis
 	addtimer(CALLBACK(C, /mob/living/carbon.proc/gain_trauma, /datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY, hearing_args[HEARING_RAW_MESSAGE]), 10)
 	addtimer(CALLBACK(C, /mob/living.proc/Stun, 60, TRUE, TRUE), 15) //Take some time to think about it

--- a/config/sandstorm/config.txt
+++ b/config/sandstorm/config.txt
@@ -11,3 +11,10 @@
 ## Dogborg Sleeper Mechanics ###
 ## Uncomment to enable regular dogborg sleepers (otherwise will use recreational)
 #ENABLE_DOGBORG_SLEEPERS
+
+## Hypnotic Stupor Tweaks ###
+## Uncomment to limit hypnotic stupor trances.
+## Duration until a new trance is applied is random between MIN and MAX in deciseconds
+LIMIT_STUPOR_TRANCES
+MIN_STUPOR_HYPNO_DURATION 6000
+MAX_STUPOR_HYPNO_DURATION 12000


### PR DESCRIPTION
Fix dangling parentheses breaking regex in hypnotic stupor
Added optional limits to how often a hypnotic stupor can apply a trance

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes dangling parentheses breaking regex in hypnosis and establishes a minimum duration that a hypnosis from the quirk Hypnotic Stupor (via Trance status effect) must persist.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The bugfix fixes runtime error spam (every tick in Life()) and allows brain traumas to actually process (there must not be a null brain trauma). The tweak to hypnotic stupor is because despite there only being a 1% chance every tick to trigger a Trance, it still can make hypnosis rapidly change making it difficult to roleplay into that command.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Nope.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
tweak: Changed Hypnotic Stupor quirk to only reapply a trance after a minimum amount of time from a previous hypnosis
fix: Hypnosis phrase should now be properly escaped for regex (e.g. dangling parentheses)
config: Added configs for Hypnotic Stupor quirk tweaks (defaults on with a minimum hypnosis duration between 10 and 20 minutes)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
