### PR TITLE
Fix? for nullref during hallucination sleep

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -698,7 +698,8 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 		if(target.client)
 			target.client.images |= speech_overlay
 			sleep(30)
-			target.client.images.Remove(speech_overlay)
+			if (target.client)
+				target.client.images.Remove(speech_overlay)
 		var/spans = list(person.speech_span)
 		if (target.client?.prefs.chat_on_map)
 			target.create_chat_message(person, understood_language, chosen, spans, 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a nullcheck for a likely very rare edgecase runtime error the server may experience when running a chat hallucination but the client's reference is lost during the 30 deciseconds the script is asleep.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improves server stability (wasn't a crash, but likely would prevent any hallucinations from ever running from then on)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Nope.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
fix: Added another nullcheck for a rare edge case runtime exception for a lost reference during a sleep step in Hallucination.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
