### PR TITLE
Fix for proc override validity in bubblegumhard because of missing pa…

### DIFF
--- a/sandcode/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegumhard.dm
+++ b/sandcode/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegumhard.dm
@@ -322,7 +322,7 @@ obj/item/gps/internal/bubblegum/hard
 	if(useoriginal)
 		charge(chargeat, delay, chargepast)
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/hard/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hard/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE, only_robotic = FALSE, only_organic = TRUE)
 	. = ..()
 	if(. > 0 && prob(25))
 		var/obj/effect/decal/cleanable/blood/gibs/bubblegumhard/B = new /obj/effect/decal/cleanable/blood/gibs/bubblegumhard(loc)
@@ -466,7 +466,7 @@ obj/item/gps/internal/bubblegum/hard
 /mob/living/simple_animal/hostile/megafauna/bubblegum/hard/hallucination/Life()
 	return
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/hard/hallucination/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hard/hallucination/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE, only_robotic = FALSE, only_organic = TRUE)
 	return
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/hard/hallucination/OpenFire()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Dreamchecker (one of the linter tests in Travis) found two proc override validity errors in sandcode's Bubblegum Hard hostile mob since it seems pulls from citadel added additional parameters to mob/living/proc/adjustBruteLoss: only_robotic and only_organic that would have likely caused a runtime error inside the Regenerative Core Tendrils status effect.

Linter error:
code/modules/mob/living/damage_procs.dm, line 145, column 33:
error: 2 overrides of /mob/living/proc/adjustBruteLoss are missing keyword args
- sandcode/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegumhard.dm:325:75: /mob/living/simple_animal/hostile/megafauna/bubblegum/hard is missing "only_organic"
- sandcode/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegumhard.dm:469:89: /mob/living/simple_animal/hostile/megafauna/bubblegum/hard/hallucination is missing "only_organic"
- code/datums/status_effects/buffs.dm:584:7: called with "only_organic" here, and 1 other places
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Game runtime stability and to make test scripts happy!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Nope.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
fix: Fixed potential runtime error in Bubblegum hard's parameters for proc adjustBruteLoss via Regenerative Core Tendrils
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
