### PR TITLE
Force gamemode config

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -179,7 +179,10 @@ SUBSYSTEM_DEF(ticker)
 				timeLeft = 0
 
 			if(!modevoted)
-				send_gamemode_vote()
+				if(!CONFIG_GET(string/force_gamemode))
+					send_gamemode_vote()
+				else
+					force_gamemode(CONFIG_GET(string/force_gamemode))
 			//countdown
 			if(timeLeft < 0)
 				return
@@ -238,12 +241,14 @@ SUBSYSTEM_DEF(ticker)
 				var/datum/game_mode/smode = config.pick_mode(GLOB.secret_force_mode)
 				if(!smode.can_start())
 					message_admins("<span class='notice'>Unable to force secret [GLOB.secret_force_mode]. [smode.required_players] players and [smode.required_enemies] eligible antagonists needed.</span>")
+					force_gamemode("extended")
 				else
 					mode = smode
 
 		if(!mode)
 			if(!runnable_modes.len)
 				to_chat(world, "<B>Unable to choose playable game mode.</B> Reverting to pre-game lobby.")
+				force_gamemode("extended")
 				return 0
 			mode = pickweight(runnable_modes)
 			if(!mode)	//too few roundtypes all run too recently
@@ -256,6 +261,7 @@ SUBSYSTEM_DEF(ticker)
 			qdel(mode)
 			mode = null
 			SSjob.ResetOccupations()
+			force_gamemode("extended")
 			return 0
 
 	CHECK_TICK
@@ -274,6 +280,7 @@ SUBSYSTEM_DEF(ticker)
 			QDEL_NULL(mode)
 			to_chat(world, "<B>Error setting up [GLOB.master_mode].</B> Reverting to pre-game lobby.")
 			SSjob.ResetOccupations()
+			force_gamemode("extended")
 			return 0
 	else
 		message_admins("<span class='notice'>DEBUG: Bypassing prestart checks...</span>")

--- a/config/sandstorm/config.txt
+++ b/config/sandstorm/config.txt
@@ -31,3 +31,9 @@ MAX_STUPOR_HYPNO_DURATION 12000
 ## Maxmimum amount of languages someone can pick
 ## -1 means infinite and 0 disables it
 #MAX_LANGUAGES
+
+## Force Gamemode ##
+## Disallows roundstart gamemode voting if not null or commented
+## Just input the gamemode lowercase in there, the thing will take a simple string for it
+## Invalid gamemodes will default extended, have fun.
+#FORCE_GAMEMODE

--- a/modular_sand/code/controllers/configuration/entries/sandstorm.dm
+++ b/modular_sand/code/controllers/configuration/entries/sandstorm.dm
@@ -12,3 +12,6 @@
 /datum/config_entry/number/max_languages
 	config_entry_value = 1
 	min_val = -1
+
+/datum/config_entry/string/force_gamemode
+	config_entry_value = null

--- a/modular_sand/code/controllers/subsystem/ticker.dm
+++ b/modular_sand/code/controllers/subsystem/ticker.dm
@@ -1,0 +1,12 @@
+/datum/controller/subsystem/ticker/proc/force_gamemode(gamemode)
+	if(gamemode)
+		if(!modevoted)
+			modevoted = TRUE
+		if(gamemode in config.modes)
+			GLOB.master_mode = gamemode
+			SSticker.save_mode(gamemode)
+			message_admins("The gamemode has been set to [gamemode].")
+		else
+			GLOB.master_mode = "extended"
+			SSticker.save_mode("extended")
+			message_admins("force_gamemode proc received an invalid gamemode, defaulting to extended.")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3706,6 +3706,7 @@
 #include "modular_sand\code\_onclick\hud\screen_objects.dm"
 #include "modular_sand\code\controllers\configuration\entries\sandstorm.dm"
 #include "modular_sand\code\controllers\subsystem\language.dm"
+#include "modular_sand\code\controllers\subsystem\ticker.dm"
 #include "modular_sand\code\datums\action.dm"
 #include "modular_sand\code\datums\ai_laws.dm"
 #include "modular_sand\code\datums\shuttles.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
Locks gamemodes to a default set by the server operator, of course it can still be turned off or admins change it.
Also if any other gamemode fails starting up, it will default to extended.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now it is indeed extended forever.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
fix: No more infinite unable to start rounds, if it happens the game should force to start extended.
config: Voting can now be disabled to allow for a single gamemode type.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
