### PR TITLE
Fixes some sprite accesory paths

### DIFF
--- a/modular_sand/code/modules/mob/dead/new_player/sprite_accessories/body_markings.dm
+++ b/modular_sand/code/modules/mob/dead/new_player/sprite_accessories/body_markings.dm
@@ -1,4 +1,4 @@
-/datum/sprite_accessory/body_markings/colorbelly
+/datum/sprite_accessory/mam_body_markings/colorbelly
 	name = "Coloured Belly"
 	color_src = MATRIXED
 	icon_state = "colorbelly"

--- a/modular_sand/code/modules/mob/dead/new_player/sprite_accessories/ears.dm
+++ b/modular_sand/code/modules/mob/dead/new_player/sprite_accessories/ears.dm
@@ -1,10 +1,10 @@
-/datum/sprite_accessory/mam_ears/cobrahood
+/datum/sprite_accessory/ears/mam_ears/cobrahood
 	name = "Cobra Hood"
 	icon_state = "cobrahood"
 	icon = 'modular_sand/icons/mob/mam_ears.dmi'
 	color_src = MATRIX_RED_GREEN
 
-/datum/sprite_accessory/mam_ears/cobrahoodears
+/datum/sprite_accessory/ears/mam_ears/cobrahoodears
 	name = "Cobra Hood (Ears)"
 	icon_state = "cobraears"
 	icon = 'modular_sand/icons/mob/mam_ears.dmi'

--- a/modular_sand/code/modules/mob/dead/new_player/sprite_accessories/ears.dm
+++ b/modular_sand/code/modules/mob/dead/new_player/sprite_accessories/ears.dm
@@ -2,10 +2,12 @@
 	name = "Cobra Hood"
 	icon_state = "cobrahood"
 	icon = 'modular_sand/icons/mob/mam_ears.dmi'
-	color_src = MATRIX_RED_GREEN
+	color_src = MATRIXED
+	matrixed_sections = MATRIX_RED_GREEN
 
 /datum/sprite_accessory/ears/mam_ears/cobrahoodears
 	name = "Cobra Hood (Ears)"
 	icon_state = "cobraears"
 	icon = 'modular_sand/icons/mob/mam_ears.dmi'
-	color_src = MATRIX_RED_GREEN
+	color_src = MATRIXED
+	matrixed_sections = MATRIX_RED_GREEN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The path being wrong results in stuff like not being choosable in several places, for example, slime body alteration.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
fix: Fixes incorrect pathing for sprite accessories.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
