### PR TITLE
Prevents underwear from using direction sprites on the floor

### DIFF
--- a/modular_sand/code/modules/clothing/underwear/_underwear.dm
+++ b/modular_sand/code/modules/clothing/underwear/_underwear.dm
@@ -14,6 +14,10 @@
 	var/under_type = /obj/item/clothing/underwear //i don't know what i'm gonna use this for
 	var/fitted = FEMALE_UNIFORM_TOP
 
+/obj/item/clothing/underwear/Move()
+	..()
+	setDir(SOUTH) //should prevent underwear from facing any direction but south while on the floor, uses same code as pipes, PLEASE, THIS IS A BAD SOLUTION, SOMEONE MAKE ME UNDERWEAR SPRITES ASAP
+
 ///Proc to check if undershirt is hidden.
 /mob/living/carbon/human/proc/undershirt_hidden()
 	for(var/obj/item/I in list(w_uniform, wear_suit))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Should prevent awful direction sprites while on the floor, but seriously, if only someone could provide underwear sprites (and that means for all of them).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Looks nicer and you won't have the chance of losing your underwear because it's current state has too few pixels.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
code: Forces underwear item sprite to face south.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
