### PR TITLE
Makes borg sleepers use a nicer code and revives janitor module's processor

### DIFF
--- a/code/game/objects/items/devices/dogborg_sleeper.dm
+++ b/code/game/objects/items/devices/dogborg_sleeper.dm
@@ -315,8 +315,9 @@
 				hound.sleeper_g = 1
 				patient_laststat = patient.stat
 
-			if(!patient.client || !(patient.client.prefs.cit_toggles & MEDIHOUND_SLEEPER) || !hound.client || !(hound.client.prefs.cit_toggles & MEDIHOUND_SLEEPER))
-				hound.sleeper_nv = TRUE
+			if(hound.module.sleeper_overlay == "msleeper")
+				if(!patient.client || !(patient.client.prefs.cit_toggles & MEDIHOUND_SLEEPER) || !hound.client || !(hound.client.prefs.cit_toggles & MEDIHOUND_SLEEPER))
+					hound.sleeper_nv = TRUE
 			else
 				hound.sleeper_nv = FALSE
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -184,7 +184,7 @@
 			I.icon_state = "decompiler"
 		if(istype(src, /obj/item/robot_module/butler))
 			I.icon_state = "servicer"
-			if(cyborg_base_icon == "scrubpup")
+			if(cyborg_base_icon in list("scrubpup", "drakejanit"))
 				I.icon_state = "compactor"
 
 	basic_modules += I

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -151,34 +151,43 @@
 	basic_modules += new /obj/item/dogborg_nose(src)
 	basic_modules += new /obj/item/dogborg_tongue(src)
 
-	var/obj/item/dogborg/sleeper/K9/flavour/I = new(src)
+	var/obj/item/dogborg/sleeper/I = /obj/item/dogborg/sleeper
 
 	var/mechanics = CONFIG_GET(flag/enable_dogborg_sleepers)
 	if (mechanics)
 		// Normal sleepers
 		if(istype(src, /obj/item/robot_module/security))
-			basic_modules += new /obj/item/dogborg/sleeper/K9(src)
+			I = new /obj/item/dogborg/sleeper/K9(src)
+
 		if(istype(src, /obj/item/robot_module/medical))
-			basic_modules += new /obj/item/dogborg/sleeper(src)
+			I = new /obj/item/dogborg/sleeper(src)
+
+		// "Unimplemented sleepers"
+		if(istype(src, /obj/item/robot_module/engineering))
+			I = new /obj/item/dogborg/sleeper/compactor(src)
+			I.icon_state = "decompiler"
+		if(istype(src, /obj/item/robot_module/butler))
+			I = new /obj/item/dogborg/sleeper/compactor(src)
+			I.icon_state = "servicer"
+			if(cyborg_base_icon in list("scrubpup", "drakejanit"))
+				I.icon_state = "compactor"
 	else
+		I = new /obj/item/dogborg/sleeper/K9/flavour(src) //If mechanics is a no-no, revert to flavour
 		// Recreational sleepers
 		if(istype(src, /obj/item/robot_module/security))
 			I.icon_state = "sleeperb"
-			basic_modules += I
 		if(istype(src, /obj/item/robot_module/medical))
 			I.icon_state = "sleeper"
-			basic_modules += I
 
-	// Unimplemented sleepers
-	if(istype(src, /obj/item/robot_module/engineering))
-		I.icon_state = "decompiler"
-		basic_modules += I
-	if(istype(src, /obj/item/robot_module/butler))
-		I.icon_state = "servicer"
-		if(cyborg_base_icon == "scrubpup")
-			I.icon_state = "compactor"
-		basic_modules += I
+		// Unimplemented sleepers
+		if(istype(src, /obj/item/robot_module/engineering))
+			I.icon_state = "decompiler"
+		if(istype(src, /obj/item/robot_module/butler))
+			I.icon_state = "servicer"
+			if(cyborg_base_icon == "scrubpup")
+				I.icon_state = "compactor"
 
+	basic_modules += I
 	rebuild_modules()
 
 /obj/item/robot_module/proc/remove_module(obj/item/I, delete_after)

--- a/modular_sand/code/game/objects/items/devices/dogborg_sleeper.dm
+++ b/modular_sand/code/game/objects/items/devices/dogborg_sleeper.dm
@@ -1,0 +1,68 @@
+/obj/item/storage/attackby(obj/item/dogborg/sleeper/K9, mob/user, proximity)
+	if(istype(K9))
+		K9.afterattack(src, user ,1)
+	else
+		. = ..()
+
+/obj/item/dogborg/sleeper/compactor //Janihound gut.
+	name = "garbage processor"
+	desc = "A mounted garbage compactor unit with fuel processor."
+	icon = 'icons/mob/robot_items.dmi'
+	icon_state = "compactor"
+	inject_amount = 0
+	min_health = -100
+	injection_chems = null //So they don't have all the same chems as the medihound!
+	var/max_item_count = 30
+
+/obj/item/storage/attackby(obj/item/dogborg/sleeper/compactor, mob/user, proximity) //GIT CIRCUMVENTED YO!
+	if(istype(compactor))
+		compactor.afterattack(src, user ,1)
+	else
+		. = ..()
+
+/obj/item/dogborg/sleeper/compactor/afterattack(atom/movable/target, mob/living/silicon/user, proximity)//GARBO NOMS
+	var/mob/living/silicon/robot/hound = get_host()
+	if(!hound || !istype(target) || !proximity || target.anchored)
+		return
+	if(length(contents) > (max_item_count - 1))
+		to_chat(user,"<span class='warning'>Your [src] is full. Eject or process contents to continue.</span>")
+		return
+	if(isitem(target))
+		var/obj/item/I = target
+		if(CheckAccepted(I))
+			to_chat(user,"<span class='warning'>[I] registers an error code to your [src]</span>")
+			return
+		if(I.w_class > WEIGHT_CLASS_NORMAL)
+			to_chat(user,"<span class='warning'>[I] is too large to fit into your [src]</span>")
+			return
+		user.visible_message("<span class='warning'>[hound.name] is ingesting [I] into their [src.name].</span>", "<span class='notice'>You start ingesting [target] into your [src.name]...</span>")
+		if(do_after(user, 15, target = target) && length(contents) < max_item_count)
+			I.forceMove(src)
+			I.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [I] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [I] slips inside.</span>")
+			playsound(hound, 'sound/machines/disposalflush.ogg', 50, 1)
+			if(length(contents) > 11) //grow that tum after a certain junk amount
+				hound.sleeper_r = 1
+				hound.update_icons()
+			else
+				hound.sleeper_r = 0
+				hound.update_icons()
+		return
+
+	if(iscarbon(target) || issilicon(target))
+		var/mob/living/trashman = target
+		if(!CHECK_BITFIELD(trashman.vore_flags,DEVOURABLE))
+			to_chat(user, "<span class='warning'>[target] registers an error code to your [src]</span>")
+			return
+		if(patient)
+			to_chat(user,"<span class='warning'>Your [src] is already occupied.</span>")
+			return
+		if(trashman.buckled)
+			to_chat(user,"<span class='warning'>[trashman] is buckled and can not be put into your [src].</span>")
+			return
+		user.visible_message("<span class='warning'>[hound.name] is ingesting [trashman] into their [src].</span>", "<span class='notice'>You start ingesting [trashman] into your [src.name]...</span>")
+		if(do_after(user, 30, target = trashman) && !patient && !trashman.buckled && length(contents) < max_item_count)
+			trashman.forceMove(src)
+			trashman.reset_perspective(src)
+			update_gut(user)
+			user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [trashman] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [trashman] slips inside.</span>")
+			playsound(hound, 'sound/effects/bin_close.ogg', 80, 1)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3818,6 +3818,7 @@
 #include "modular_sand\code\game\objects\items\miscellaneous.dm"
 #include "modular_sand\code\game\objects\items\circuitboards\computer_circuitboards.dm"
 #include "modular_sand\code\game\objects\items\circuitboards\machine_circuitboards.dm"
+#include "modular_sand\code\game\objects\items\devices\dogborg_sleeper.dm"
 #include "modular_sand\code\game\objects\items\devices\extra_arm.dm"
 #include "modular_sand\code\game\objects\items\devices\PDA\PDA.dm"
 #include "modular_sand\code\game\objects\items\devices\radio\headset.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, also makes so _nv is not used thus not breaking belly sprites, only the default medihound has it, shouldn't force the others to try.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes code nicer and adds something nice to garbage sweepers.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
add: Re-adds janitor module garbage processor.
fix: Borgs shouldn't be lacking belly sprites, when holding something inside.
code: Borg sleepers use better code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
