### PR TITLE
fixes some runtimes (again)

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -351,6 +351,8 @@
 			wash_obj(AM)
 
 /obj/machinery/shower/proc/wash_obj(obj/O)
+	if(!O) 
+		return
 	. = SEND_SIGNAL(O, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_WEAK)
 	. = O.clean_blood()
 	O.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)

--- a/tgui/packages/tgui/interfaces/PaperSheet.js
+++ b/tgui/packages/tgui/interfaces/PaperSheet.js
@@ -44,8 +44,16 @@ const textWidth = (text, font, fontsize) => {
   const c = document.createElement('canvas');
   const ctx = c.getContext("2d");
   ctx.font = font;
+  if (text) {
+    const width = ctx.measureText(text).width;
+    return width;
+  } else {
+    return 0;
+  }
+  /*
   const width = ctx.measureText(text).width;
   return width;
+  */
 };
 
 const setFontinText = (text, font, color, bold=false) => {
@@ -378,7 +386,7 @@ class PaperSheetStamper extends Component {
 
 // This creates the html from marked text as well as the form fields
 const createPreview = (
-  value, 
+  value,
   text,
   do_fields = false,
   field_counter,
@@ -440,7 +448,7 @@ class PaperSheetEdit extends Component {
 
   createPreviewFromData(value, do_fields = false) {
     const { data } = useBackend(this.context);
-    return createPreview(value, 
+    return createPreview(value,
       this.state.old_text,
       do_fields,
       this.state.counter,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes some errors, port of our https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/pull/80
Removed one of the runtimes for PaperSheets - where a null text was runtiming, added a check for it.
Removed one of the runtimes for the showers for when a null object is placed under the showers somehow. (added a check for it)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
i hate lag
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
kinda...?
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
fix: now it checks if a paper's content is null rather than runtiming
fix: fixes shower null objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
