### PR TITLE
Make the pick up ratio a config

### DIFF
--- a/config/sandstorm/config.txt
+++ b/config/sandstorm/config.txt
@@ -31,3 +31,9 @@ MAX_STUPOR_HYPNO_DURATION 12000
 ## Maxmimum amount of languages someone can pick
 ## -1 means infinite and 0 disables it
 #MAX_LANGUAGES
+
+## Max micro pick up ratio ##
+## The maximum size ratio between someone who's being picked up and whoever's picking them up ##
+## Eg. If set to 0.5, whoever's being picked up shall be 50% or less the size of their partner or they won't be picked up ##
+## Defaults to 0.5 if unset, 0 to disable picking up others as a whole ##
+#MAX_PICK_RATIO 0.5

--- a/modular_sand/code/controllers/configuration/entries/sandstorm.dm
+++ b/modular_sand/code/controllers/configuration/entries/sandstorm.dm
@@ -24,3 +24,8 @@
 /datum/config_entry/number/max_stupor_hypno_duration	//Maximum random duration to maintain hypnosis from hypnotic stupor
 	config_entry_value = 12000
 	min_val = 10
+
+/datum/config_entry/number/max_pick_ratio 	//Maximum ratio between pick target/picker user
+	config_entry_value = 0.5
+	min_val = 0
+	integer = FALSE

--- a/modular_sand/code/datums/elements/holder_micro.dm
+++ b/modular_sand/code/datums/elements/holder_micro.dm
@@ -35,7 +35,8 @@
 		return FALSE
 	if(!ishuman(user) || !user.Adjacent(source) || user.incapacitated())
 		return FALSE
-	if(abs(get_size(user)/get_size(source)) < 2.0 )
+	//if(abs(get_size(user)/get_size(source)) < 2.0)
+	if(abs(get_size(source)/get_size(user)) > CONFIG_GET(number/max_pick_ratio))
 		to_chat(user, "<span class='warning'>They're too big to pick up!</span>")
 		return FALSE
 	if(user.get_active_held_item())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This makes it so that you can configure what the max ratio between the person being picked up/whoever's picking them up can be or deactivate it as a whole. Tell me if you wanna use this config entry for anything else
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
this way you can configure and control it more easily depending on what you want for your station ig
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
config: made he maximum ratio for picking up people a config
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
