### PR TITLE
Modifies interaction prefs on the interaction menu

### DIFF
--- a/modular_sand/code/datums/interactions/interaction_interface.dm
+++ b/modular_sand/code/datums/interactions/interaction_interface.dm
@@ -14,7 +14,7 @@
 
 /// Allows "cyborg" players to change gender at will
 /mob/living/silicon/robot/verb/toggle_gender()
-	set category = "IC"
+	set category = "Robot Commands"
 	set name = "Set Gender"
 	set desc = "Allows you to set your gender."
 
@@ -57,6 +57,15 @@
 	if(!ui)
 		ui = new(user, src, "MobInteraction", "Interactions")
 		ui.open()
+
+/proc/pref_to_num(pref)
+	switch(pref)
+		if("Yes")
+			return 1
+		if("Ask")
+			return 2
+		else
+			return 0
 
 /datum/interaction_menu/ui_data(mob/user)
 	//Getting player
@@ -110,6 +119,7 @@
 			else
 				visibility = "Hidden by clothes"
 			genital_entry["visibility"] = visibility
+			genital_entry["possible_choices"] = GLOB.genitals_visibility_toggles
 			genitals += list(genital_entry)
 	if(iscarbon(self))
 		var/simulated_ass = list()
@@ -124,17 +134,18 @@
 			else
 				visibility = "Always hidden"
 		simulated_ass["visibility"] = visibility
+		simulated_ass["possible_choices"] = GLOB.genitals_visibility_toggles - GEN_VISIBLE_NO_CLOTHES
 		genitals += list(simulated_ass)
 	data["genitals"] = genitals
 
 	var/datum/preferences/prefs = usr?.client.prefs
 	if(prefs)
 	//Getting char prefs
-		data["erp_pref"] = 			prefs.erppref == "Ask" ? 2 : prefs.erppref == "Yes" ? 1 : 0
-		data["noncon_pref"] = 		prefs.nonconpref == "Ask" ? 2 : prefs.nonconpref == "Yes" ? 1 : 0
-		data["vore_pref"] = 		prefs.vorepref == "Ask" ? 2 : prefs.vorepref == "Yes" ? 1 : 0
-		data["extreme_pref"] = 		prefs.extremepref == "Ask" ? 2 : prefs.extremepref == "Yes" ? 1 : 0
-		data["extreme_harm"] = 		prefs.extremeharm == "Yes" ? 1 : 0
+		data["erp_pref"] = 			pref_to_num(prefs.erppref)
+		data["noncon_pref"] = 		pref_to_num(prefs.nonconpref)
+		data["vore_pref"] = 		pref_to_num(prefs.vorepref)
+		data["extreme_pref"] = 		pref_to_num(prefs.extremepref)
+		data["extreme_harm"] = 		pref_to_num(prefs.extremeharm)
 
 	//Getting preferences
 		data["verb_consent"] = 		CHECK_BITFIELD(prefs.toggles, VERB_CONSENT)
@@ -159,6 +170,15 @@
 
 	return data
 
+/proc/num_to_pref(num)
+	switch(num)
+		if(1)
+			return "Yes"
+		if(2)
+			return "Ask"
+		else
+			return "No"
+
 /datum/interaction_menu/ui_act(action, params)
 	if(..())
 		return
@@ -172,59 +192,45 @@
 		if("genital")
 			var/mob/living/carbon/self = usr
 			if(params["genital"] == "anus")
-				var/picked_visibility = tgui_input_list(usr, "Chose visibility setting", "Expose/Hide genitals", GLOB.genitals_visibility_toggles - GEN_VISIBLE_NO_CLOTHES)
-				self.anus_toggle_visibility(picked_visibility)
+				self.anus_toggle_visibility(params["visibility"])
 				return TRUE
 			var/obj/item/organ/genital/genital = locate(params["genital"], self.internal_organs)
 			if(genital && (genital in self.internal_organs))
-				var/picked_visibility = tgui_input_list(usr, "Choose visibility setting", "Expose/Hide genitals", GLOB.genitals_visibility_toggles)
-				if(picked_visibility && genital && (genital in self.internal_organs))
-					genital.toggle_visibility(picked_visibility)
-					return TRUE
+				genital.toggle_visibility(params["visibility"])
+				return TRUE
 			else
 				return FALSE
 		if("char_pref")
 			var/datum/preferences/prefs = usr.client.prefs
+			var/value = num_to_pref(params["value"])
 			switch(params["char_pref"])
 				if("erp_pref")
-					switch(prefs.erppref)
-						if("Yes")
-							prefs.erppref = "Ask"
-						if("Ask")
-							prefs.erppref = "No"
-						if("No")
-							prefs.erppref = "Yes"
+					if(prefs.erppref == value)
+						return FALSE
+					else
+						prefs.erppref = value
 				if("noncon_pref")
-					switch(prefs.nonconpref)
-						if("Yes")
-							prefs.nonconpref = "Ask"
-						if("Ask")
-							prefs.nonconpref = "No"
-						if("No")
-							prefs.nonconpref = "Yes"
+					if(prefs.nonconpref == value)
+						return FALSE
+					else
+						prefs.nonconpref = value
 				if("vore_pref")
-					switch(prefs.vorepref)
-						if("Yes")
-							prefs.vorepref = "Ask"
-						if("Ask")
-							prefs.vorepref = "No"
-						if("No")
-							prefs.vorepref = "Yes"
+					if(prefs.vorepref == value)
+						return FALSE
+					else
+						prefs.vorepref = value
 				if("extreme_pref")
-					switch(prefs.extremepref)
-						if("Yes")
-							prefs.extremepref = "Ask"
-						if("Ask")
-							prefs.extremepref = "No"
+					if(prefs.extremepref == value)
+						return FALSE
+					else
+						prefs.extremepref = value
+						if(prefs.extremepref == "No")
 							prefs.extremeharm = "No"
-						if("No")
-							prefs.extremepref = "Yes"
 				if("extreme_harm")
-					switch(prefs.extremeharm)
-						if("Yes")
-							prefs.extremeharm = "No"
-						if("No")
-							prefs.extremeharm = "Yes"
+					if(prefs.extremeharm == value)
+						return FALSE
+					else
+						prefs.extremeharm = value
 				else
 					return FALSE
 			prefs.save_character()

--- a/tgui/packages/tgui/interfaces/MobInteraction.js
+++ b/tgui/packages/tgui/interfaces/MobInteraction.js
@@ -1,6 +1,6 @@
 import { map } from 'common/collections';
 import { useBackend, useLocalState } from '../backend';
-import { Button, Section, BlockQuote, Flex, Tabs } from '../components';
+import { BlockQuote, Button, Flex, LabeledList, Section, Tabs } from '../components';
 import { Window } from '../layouts';
 
 export const MobInteraction = (props, context) => {
@@ -89,21 +89,36 @@ const InteractionsTab = (props, context) => {
   );
 };
 
+const ModeToIcon = {
+  "Always visible": "eye",
+  "Hidden by clothes": "tshirt",
+  "Hidden by underwear": "low-vision",
+  "Always hidden": "eye-slash",
+};
+
 const GenitalVisibilityTab = (props, context) => {
   const { act, data } = useBackend(context);
   const genitals = data.genitals || [];
   return (
     genitals.length ? (
       <Flex direction="column">
-        {genitals.map(genital => (
-          <Button
-            key={genital['key']}
-            content={genital['name'] + " = " + genital["visibility"]}
-            icon={genital['visibility'] === "Always visible" ? "eye" : "eye-slash"}
-            onClick={() => act('genital', {
-              genital: genital['key'],
-            })} />
-        ))}
+        <LabeledList>
+          {genitals.map(genital => (
+            <LabeledList.Item key={genital['key']} label={genital['name']}>
+              {genital.possible_choices.map(choice => (
+                <Button
+                  key={choice}
+                  tooltip={choice}
+                  icon={ModeToIcon[choice]}
+                  color={genital.visibility === choice ? "green" : "default"}
+                  onClick={() => act('genital', {
+                    genital: genital['key'],
+                    visibility: choice,
+                  })} />
+              ))}
+            </LabeledList.Item>
+          ))}
+        </LabeledList>
       </Flex>
     ) : ("You don't seem to have any genitals... Or any that you could modify")
   );
@@ -120,43 +135,118 @@ const CharacterPrefsTab = (props, context) => {
   } = data;
   return (
     <Flex direction="column">
-      <Button
-        content="ERP"
-        icon={erp_pref === 2 ? "question" : erp_pref === 1 ? "check" : "times"}
-        color={erp_pref === 2 ? "yellow" : erp_pref === 1 ? "green" : "red"}
-        onClick={() => act('char_pref', {
-          char_pref: 'erp_pref',
-        })} />
-      <Button
-        content="Non-Con"
-        icon={noncon_pref === 2 ? "question" : noncon_pref === 1 ? "check" : "times"}
-        color={noncon_pref === 2 ? "yellow" : noncon_pref === 1 ? "green" : "red"}
-        onClick={() => act('char_pref', {
-          char_pref: 'noncon_pref',
-        })} />
-      <Button
-        content="Vore"
-        icon={vore_pref === 2 ? "question" : vore_pref === 1 ? "check" : "times"}
-        color={vore_pref === 2 ? "yellow" : vore_pref === 1 ? "green" : "red"}
-        onClick={() => act('char_pref', {
-          char_pref: 'vore_pref',
-        })} />
-      <Button
-        content="Extreme ERP verbs"
-        icon={extreme_pref === 2 ? "question" : extreme_pref === 1 ? "check" : "times"}
-        color={extreme_pref === 2 ? "yellow" : extreme_pref === 1 ? "green" : "red"}
-        onClick={() => act('char_pref', {
-          char_pref: 'extreme_pref',
-        })} />
-      {extreme_pref ? (
-        <Button
-          content="Harmful ERP verbs"
-          icon={extreme_harm ? "toggle-on" : "toggle-off"}
-          color={extreme_harm ? "red" : "orange"}
-          onClick={() => act('char_pref', {
-            char_pref: 'extreme_harm',
-          })} />
-      ) : (null)}
+      <LabeledList>
+        <LabeledList.Item label="ERP Preference">
+          <Button
+            icon={"check"}
+            color={erp_pref === 1 ? "green" : "default"}
+            onClick={() => act('char_pref', {
+              char_pref: 'erp_pref',
+              value: 1,
+            })} />
+          <Button
+            icon={"question"}
+            color={erp_pref === 2 ? "yellow" : "default"}
+            onClick={() => act('char_pref', {
+              char_pref: 'erp_pref',
+              value: 2,
+            })} />
+          <Button
+            icon={"times"}
+            color={erp_pref === 0 ? "red" : "default"}
+            onClick={() => act('char_pref', {
+              char_pref: 'erp_pref',
+              value: 0,
+            })} />
+        </LabeledList.Item>
+        <LabeledList.Item label="Noncon Preference">
+          <Button
+            icon={"check"}
+            color={noncon_pref === 1 ? "green" : "default"}
+            onClick={() => act('char_pref', {
+              char_pref: 'noncon_pref',
+              value: 1,
+            })} />
+          <Button
+            icon={"question"}
+            color={noncon_pref === 2 ? "yellow" : "default"}
+            onClick={() => act('char_pref', {
+              char_pref: 'noncon_pref',
+              value: 2,
+            })} />
+          <Button
+            icon={"times"}
+            color={noncon_pref === 0 ? "red" : "default"}
+            onClick={() => act('char_pref', {
+              char_pref: 'noncon_pref',
+              value: 0,
+            })} />
+        </LabeledList.Item>
+        <LabeledList.Item label="Vore Preference">
+          <Button
+            icon={"check"}
+            color={vore_pref === 1 ? "green" : "default"}
+            onClick={() => act('char_pref', {
+              char_pref: 'vore_pref',
+              value: 1,
+            })} />
+          <Button
+            icon={"question"}
+            color={vore_pref === 2 ? "yellow" : "default"}
+            onClick={() => act('char_pref', {
+              char_pref: 'vore_pref',
+              value: 2,
+            })} />
+          <Button
+            icon={"times"}
+            color={vore_pref === 0 ? "red" : "default"}
+            onClick={() => act('char_pref', {
+              char_pref: 'vore_pref',
+              value: 0,
+            })} />
+        </LabeledList.Item>
+        <LabeledList.Item label="Extreme Preference">
+          <Button
+            icon={"check"}
+            color={extreme_pref === 1 ? "green" : "default"}
+            onClick={() => act('char_pref', {
+              char_pref: 'extreme_pref',
+              value: 1,
+            })} />
+          <Button
+            icon={"question"}
+            color={extreme_pref === 2 ? "yellow" : "default"}
+            onClick={() => act('char_pref', {
+              char_pref: 'extreme_pref',
+              value: 2,
+            })} />
+          <Button
+            icon={"times"}
+            color={extreme_pref === 0 ? "red" : "default"}
+            onClick={() => act('char_pref', {
+              char_pref: 'extreme_pref',
+              value: 0,
+            })} />
+        </LabeledList.Item>
+        {extreme_pref ? (
+          <LabeledList.Item label="Extreme Harm">
+            <Button
+              icon={"check"}
+              color={extreme_harm === 1 ? "green" : "default"}
+              onClick={() => act('char_pref', {
+                char_pref: 'extreme_harm',
+                value: 1,
+              })} />
+            <Button
+              icon={"times"}
+              color={extreme_harm === 0 ? "red" : "default"}
+              onClick={() => act('char_pref', {
+                char_pref: 'extreme_harm',
+                value: 0,
+              })} />
+          </LabeledList.Item>
+        ) : (null)}
+      </LabeledList>
     </Flex>
   );
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
![sOkSJpqgsG](https://user-images.githubusercontent.com/43283559/147503782-6047b73c-f57c-4b1d-a3b6-db890b2330fd.gif)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The window from genital picking was awful, and the other tab felt right to have those.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
tweak: Set-Gender for borgs was moved to Robot Commands tab on the statpanel.
tweak: Beautified some ui on the interaction menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
