### PR TITLE
Adds a command for admins to easily end the shift (calls shuttle) + misc stuff

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -388,8 +388,9 @@ GLOBAL_LIST_EMPTY(species_datums)
 			override = TRUE
 		if(HAS_TRAIT(M, TRAIT_SIXTHSENSE))
 			override = TRUE
-		if(SSticker.current_state == GAME_STATE_FINISHED)
-			override = TRUE
+		if(CONFIG_GET(flag/reveal_everything))
+			if(SSticker.current_state == GAME_STATE_FINISHED)
+				override = TRUE
 		if(isnewplayer(M) && !override)
 			continue
 		if(M.stat != DEAD && !override)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -249,8 +249,7 @@
 			for(var/m in GLOB.player_list)
 				var/mob/M = m
 				H.add_hud_to(M)
-
-	CHECK_TICK
+		CHECK_TICK
 
 	//Set news report and mode result
 	mode.set_round_result()
@@ -274,8 +273,7 @@
 	// handle_hearts()
 	if(CONFIG_GET(flag/reveal_everything))
 		set_observer_default_invisibility(0, "<span class='warning'>The round is over! You are now visible to the living.</span>")
-
-	CHECK_TICK
+		CHECK_TICK
 
 	//These need update to actually reflect the real antagonists
 	//Print a list of antagonists to the server log

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -60,6 +60,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/jumptokey,				/*allows us to jump to the location of a mob with a certain ckey*/
 	/client/proc/jumptomob,				/*allows us to jump to a specific mob*/
 	/client/proc/jumptoturf,			/*allows us to jump to a specific turf*/
+	/client/proc/admin_end_shift,		/*allows us to end the shift properly, also logs it*/
 	/client/proc/admin_call_shuttle,	/*allows us to call the emergency shuttle*/
 	/client/proc/admin_cancel_shuttle,	/*allows us to cancel the emergency shuttle, sending it back to centcom*/
 	// /client/proc/admin_disable_shuttle, /*allows us to disable the emergency shuttle admin-wise so that it cannot be called*/
@@ -228,6 +229,7 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	/client/proc/cmd_admin_headset_message,
 	/client/proc/cmd_admin_check_contents,
 	/datum/admins/proc/access_news_network,
+	/client/proc/admin_end_shift,
 	/client/proc/admin_call_shuttle,
 	/client/proc/admin_cancel_shuttle,
 	/client/proc/cmd_admin_direct_narrate,

--- a/modular_sand/code/modules/admin/verbs/randomverbs.dm
+++ b/modular_sand/code/modules/admin/verbs/randomverbs.dm
@@ -1,0 +1,20 @@
+/client/proc/admin_end_shift()
+	set category = "Admin.Events"
+	set name = "End shift"
+	set desc = "Calls the shuttle as if a roundend vote passed."
+
+	if(EMERGENCY_AT_LEAST_DOCKED)
+		return
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	var/confirm = alert(src, "End the shift?", "Confirm", "Yes", "No")
+	if(confirm != "Yes")
+		return
+
+	SSshuttle.autoEnd()
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "End Shift") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	log_admin("[key_name(usr)] ended the shift.")
+	message_admins("<span class='adminnotice'>[key_name_admin(usr)] ended the shift.</span>")
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3948,6 +3948,7 @@
 #include "modular_sand\code\game\turfs\simulated\floor\plating.dm"
 #include "modular_sand\code\game\turfs\simulated\floor\titanium_floor.dm"
 #include "modular_sand\code\modules\admin\verbs\fix_air.dm"
+#include "modular_sand\code\modules\admin\verbs\randomverbs.dm"
 #include "modular_sand\code\modules\arousal\arousal.dm"
 #include "modular_sand\code\modules\arousal\creampie.dm"
 #include "modular_sand\code\modules\arousal\organs\breasts.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Helpful.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
add: Admins have a special shiny button to end the round ic.
fix: No longer calling CHECK_TICKs for no reason.
config: If reveal everything is false, ghosts can no longer speak to the living when the round ends.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
