### PR TITLE
dreamchecker + python update

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -591,9 +591,9 @@
 		switch(child)
 			if(/datum)
 				return null
-			if(/obj || /mob)
+			if(/obj, /mob)
 				return /atom/movable
-			if(/area || /turf)
+			if(/area, /turf)
 				return /atom
 			else
 				return /datum

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -224,6 +224,7 @@
 				else
 					to_chat(owner, "<span class='userdanger'>You feel your heart lurching in your chest...</span>")
 					owner.adjustOxyLoss(8)
+		else
 
 /datum/brain_trauma/severe/discoordination
 	name = "Discoordination"
@@ -265,7 +266,7 @@
 	var/min_hypno_duration = 6000
 	var/max_hypno_duration = 12000
 	var/hypno_duration = -1 // 0 or some world time limits, whereas -1 has old behavior
-	
+
 /datum/brain_trauma/severe/hypnotic_stupor/on_gain()
 	..()
 	min_hypno_duration = CONFIG_GET(number/min_stupor_hypno_duration) // 6000
@@ -281,7 +282,7 @@
 	if(prob(1) && !owner.has_status_effect(/datum/status_effect/trance))
 		if (world.time > hypno_duration) // Only re-trance every so often
 			owner.apply_status_effect(/datum/status_effect/trance, rand(100,300), FALSE, hypno_duration > -1)
-			
+
 /datum/brain_trauma/severe/hypnotic_stupor/proc/on_hypnosis()
 	if (hypno_duration > -1)
 		hypno_duration = world.time + rand(min_hypno_duration, max_hypno_duration)

--- a/code/datums/diseases/dna_spread.dm
+++ b/code/datums/diseases/dna_spread.dm
@@ -30,7 +30,7 @@
 		return
 
 	switch(stage)
-		if(2 || 3) //Pretend to be a cold and give time to spread.
+		if(2, 3) //Pretend to be a cold and give time to spread.
 			if(prob(8))
 				affected_mob.emote("sneeze")
 			if(prob(8))

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -374,7 +374,7 @@ GLOBAL_LIST_EMPTY(allConsoles)
 				radio_freq = FREQ_ENGINEERING
 			if("security")
 				radio_freq = FREQ_SECURITY
-			if("cargobay" || "mining")
+			if("cargobay", "mining")
 				radio_freq = FREQ_SUPPLY
 		Radio.set_frequency(radio_freq)
 

--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -70,9 +70,9 @@
 
 /obj/machinery/atmospherics/pipe/layer_manifold/SetInitDirections()
 	switch(dir)
-		if(NORTH || SOUTH)
+		if(NORTH, SOUTH)
 			initialize_directions = NORTH|SOUTH
-		if(EAST || WEST)
+		if(EAST, WEST)
 			initialize_directions = EAST|WEST
 
 /obj/machinery/atmospherics/pipe/layer_manifold/isConnectable(obj/machinery/atmospherics/target, given_layer)

--- a/code/modules/hydroponics/hydroponics_chemreact.dm
+++ b/code/modules/hydroponics/hydroponics_chemreact.dm
@@ -12,7 +12,7 @@
 
 
 /obj/machinery/hydroponics/proc/mutation_roll(mob/user)
-	switch(rand(100))
+	switch(rand(1, 100))
 		if(91 to 100)
 			adjustHealth(-10)
 			visible_message("<span class='warning'>\The [myseed.plantname] starts to wilt and burn!</span>")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -144,6 +144,8 @@
 				newletter = "nglu"
 			if(5)
 				newletter = "glor"
+			else
+			
 		. += newletter
 	return sanitize(.)
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -347,10 +347,10 @@
 	var/dir2 = 0
 	var/dir3 = 0
 	switch(direction)
-		if(NORTH||SOUTH)
+		if(NORTH, SOUTH)
 			dir2 = 4
 			dir3 = 8
-		if(EAST||WEST)
+		if(EAST, WEST)
 			dir2 = 1
 			dir3 = 2
 	var/turf/T2 = T

--- a/code/modules/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -145,6 +145,7 @@
 		if(7)
 			new /obj/item/clothing/glasses/sunglasses(src)
 			new /obj/item/clothing/mask/cigarette/rollie(src)
+		else
 
 /obj/structure/closet/crate/grave/open(mob/living/user, obj/item/S)
 	if(!opened)

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -48,6 +48,7 @@
 			target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_SURGERY)
 		if(3)
 			target.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_SURGERY)
+		else
 	// you're cutting off a part of the brain.w
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)
 	B.applyOrganDamage(50, 100)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -473,6 +473,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 					tilt(user)
 				if(91 to 100)
 					tilt(user, crit=TRUE)
+				else
 
 /obj/machinery/vending/proc/freebie(mob/fatty, freebies)
 	visible_message(span_notice("[src] yields [freebies > 1 ? "several free goodies" : "a free goody"]!"))

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -18,7 +18,7 @@ export NODE_VERSION_PRECISE=12.22.4
 export SPACEMAN_DMM_VERSION=suite-1.7
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.6.8
+export PYTHON_VERSION=3.7.9
 
 # Auxmos git tag
 export AUXMOS_VERSION=v0.3.0

--- a/modular_citadel/code/modules/eventmaps/Spookystation/JTGSZwork.dm
+++ b/modular_citadel/code/modules/eventmaps/Spookystation/JTGSZwork.dm
@@ -630,19 +630,19 @@ GLOBAL_LIST_EMPTY(rain_sounds)
 		playchime = 1
 
 	switch(hour)
-		if(1 || 2)
+		if(1, 2)
 			HRimgstate = "asshouroverlay-2" //Now it is ass, mostly because someones going to kill me for the other names.
 		if(3)
 			HRimgstate = "asshouroverlay-3"
-		if(4 || 5)
+		if(4, 5)
 			HRimgstate = "asshouroverlay-4"
 		if(6)
 			HRimgstate = "asshouroverlay-6"
-		if(7 || 8)
+		if(7, 8)
 			HRimgstate = "asshouroverlay-7"
 		if(9)
 			HRimgstate = "asshouroverlay-9"
-		if(10 || 11)
+		if(10, 11)
 			HRimgstate = "asshouroverlay-10"
 		else
 			HRimgstate = "asshouroverlay-0" //Station time wraps to 0, and so does our hours.

--- a/modular_sand/code/datums/interactions/lewd/_lewd_extra.dm
+++ b/modular_sand/code/datums/interactions/lewd/_lewd_extra.dm
@@ -41,9 +41,9 @@
 						'modular_sand/sound/interactions/oral2.ogg'), 70, 1, -1)
 
 	switch(milkers.size)
-		if("c" || "d" || "e")
+		if("c", "d", "e")
 			modifier = 2
-		if("f" || "g" || "h")
+		if("f", "g", "h")
 			modifier = 3
 		else
 			if(milkers.size in milkers.breast_values)

--- a/modular_sand/code/datums/interactions/lewd/lewd_datums.dm
+++ b/modular_sand/code/datums/interactions/lewd/lewd_datums.dm
@@ -126,9 +126,9 @@
 			var/modifier = 1
 			var/obj/item/organ/genital/breasts/B = target.getorganslot(ORGAN_SLOT_BREASTS)
 			switch(B.size)
-				if("c" || "d" || "e")
+				if("c", "d", "e")
 					modifier = 2
-				if("f" || "g" || "h")
+				if("f", "g", "h")
 					modifier = 3
 				else
 					if(B.size in B.breast_values)
@@ -146,9 +146,9 @@
 			var/modifier = 1
 			var/obj/item/organ/genital/breasts/B = target.getorganslot(ORGAN_SLOT_BREASTS)
 			switch(B.size)
-				if("c" || "d" || "e")
+				if("c", "d", "e")
 					modifier = 2
-				if("f" || "g" || "h")
+				if("f", "g", "h")
 					modifier = 3
 				else
 					if(B.size in B.breast_values)
@@ -167,9 +167,9 @@
 			var/modifier = 1
 			var/obj/item/organ/genital/breasts/B = target.getorganslot(ORGAN_SLOT_BREASTS)
 			switch(B.size)
-				if("c" || "d" || "e")
+				if("c", "d", "e")
 					modifier = 2
-				if("f" || "g" || "h")
+				if("f", "g", "h")
 					modifier = 3
 				else
 					if(B.size in B.breast_values)

--- a/modular_sand/code/modules/mob/living/simple_animal/hostile/megafauna/sif.dm
+++ b/modular_sand/code/modules/mob/living/simple_animal/hostile/megafauna/sif.dm
@@ -214,11 +214,13 @@ Difficulty: Medium
 		switch(rand(0,100))
 			if(0 to 1)
 				passed = 1
+			else
 
 	if(enraged)
 		switch(rand(0,100))
 			if(0 to 5)
 				passed = 1
+			else
 
 	if(passed == 1)
 		visible_message("<span class='danger'>[src] dodged the projectile!</span>", "<span class='userdanger'>You dodge the projectile!</span>")

--- a/tools/bootstrap/python.bat
+++ b/tools/bootstrap/python.bat
@@ -1,1 +1,2 @@
-@call powershell.exe -NoLogo -ExecutionPolicy Bypass -File "%~dp0\python_.ps1" %*
+@echo off
+call powershell.exe -NoLogo -ExecutionPolicy Bypass -File "%~dp0\python_.ps1" %*

--- a/tools/bootstrap/python37._pth
+++ b/tools/bootstrap/python37._pth
@@ -1,4 +1,4 @@
-python36.zip
+python37.zip
 .
 ..\..\..
 

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -50,7 +50,7 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 
 	# Copy a ._pth file without "import site" commented, so pip will work
-	Copy-Item "$Bootstrap/python36._pth" $PythonDir `
+	Copy-Item "$Bootstrap/python37._pth" $PythonDir `
 		-ErrorAction Stop
 
 	Remove-Item $Archive

--- a/tools/mapmerge2/convert.py
+++ b/tools/mapmerge2/convert.py
@@ -4,4 +4,4 @@ from . import frontend, dmm
 if __name__ == '__main__':
     settings = frontend.read_settings()
     for fname in frontend.process(settings, "convert"):
-        dmm.DMM.from_file(fname).to_file(fname, settings.tgm)
+        dmm.DMM.from_file(fname).to_file(fname, tgm = settings.tgm)

--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -58,7 +58,7 @@ class DMM:
         self.grid[coord] = self.get_or_generate_key(tile)
 
     def generate_new_key(self):
-        free_keys = self._ensure_free_keys(1)
+        self._ensure_free_keys(1)
         max_key = max_key_for(self.key_length)
         # choose one of the free keys at random
         key = random.randint(0, max_key - 1)

--- a/tools/mapmerge2/fixup.py
+++ b/tools/mapmerge2/fixup.py
@@ -96,7 +96,7 @@ def main(repo):
                     converted[path] = merge_map(head_files[path], dmm.DMM.from_bytes(data))
         if len(working_commit.parents) != 1:
             print("A merge commit was encountered before good versions of these maps were found:")
-            print("\n".join(f"    {x}" for x in head_files.keys() - base_files.keys()))
+            print("\n".join(f"    {x}" for x in head_files.keys() - converted.keys()))
             return 1
         working_commit = working_commit.parents[0]
 

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,6 +1,6 @@
 pygit2==1.0.1
 bidict==0.13.1
-Pillow==8.3.2
+Pillow==9.0.0
 
 # changelogs
 PyYaml==5.4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This both fixes the warnings now popping on dreamchecker after it updated, I think. Also ports https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/pull/181 (which is essentially a port of https://github.com/tgstation/tgstation/pull/64246)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Opening the code to see 28 warnings ain't very good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Part of it is a port from tg ig
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
code: Made some switch statements comply with the current dreamchecker
code: Bumped python to 3.7.9
code: Bumps pillow back to 9.0.0 (yeah the problem is fixed now)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
