### PR TITLE
Fixes tops

### DIFF
--- a/modular_sand/code/modules/clothing/underwear/shirts.dm
+++ b/modular_sand/code/modules/clothing/underwear/shirts.dm
@@ -80,12 +80,12 @@
 	name = "red bikini"
 	icon_state = "swimming_red"
 
-/obj/item/clothing/underwear/top/bra_binder
+/obj/item/clothing/underwear/shirt/top/bra_binder
 	name = "Bra (binder)"
 	icon_state = "bra_binder"
 	body_parts_covered = CHEST
 
-/obj/item/clothing/underwear/top/bra_binder/strapless
+/obj/item/clothing/underwear/shirt/top/bra_binder/strapless
 	name = "Bra (binder, strapless)"
 	icon_state = "bra_binder_strapless"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The way tops were declared you were forced to use them in the normal underwear slot. This makes them use the shirt one as I guess it was intended to
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now you can wear a top + undies instead of having to choose either
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
bugfix: Tops will now use the shirt slot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
