### PR TITLE
Makes the workflow actually work as it was intended

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -1,12 +1,10 @@
 name: Compile changelogs
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'html/changelogs/**'
-      - '!html/changelogs/archive/**'
+  workflow_run:
+    workflows: [Make changelogs]
+    types:
+      - completed
 
 jobs:
   compile:


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The way it currently is it will never activate for a pr. You have to push directly to master and make sure your push edits the folders mentioned in the workflow run. Since the Makce changelogs workflow skips every other workflow when it's pushed, it basically made compilation never run. With this edit, it will run whenever the Make changelogs workflow is done running, which works both for pull requests and for pushing directly to master. Essentially making it work as it was intended
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Compile changelogs is currently ultra-borked
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
code: Fixed the Compile changelogs workflow so it actually runs and is also more responsive as it was intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
