### PR TITLE
Mob holders + size

### DIFF
--- a/code/__SANDCODE/DEFINES/signals.dm
+++ b/code/__SANDCODE/DEFINES/signals.dm
@@ -1,3 +1,5 @@
 // /datum/component/container_item
 /// (atom/container, mob/user) - returns bool
 #define COMSIG_CONTAINER_TRY_ATTACH "container_try_attach"
+//For stuff that happens when a mob changes size
+#define COMSIG_MOBSIZE_CHANGED "mobsize_changed"

--- a/modular_sand/code/datums/dna.dm
+++ b/modular_sand/code/datums/dna.dm
@@ -1,0 +1,6 @@
+/datum/dna/update_body_size(old_size)
+	. = ..()
+	if(!holder || features["body_size"] == old_size)
+		return
+
+	holder.adjust_mobsize()

--- a/modular_sand/code/datums/elements/holder_micro.dm
+++ b/modular_sand/code/datums/elements/holder_micro.dm
@@ -147,3 +147,16 @@
 /obj/item/clothing/head/mob_holder/micro/attack(mob/living/pred, mob/living/user)
 	user.vore_attack(user, held_mob, pred)
 	return STOP_ATTACK_PROC_CHAIN
+
+/obj/item/clothing/head/mob_holder/micro/verb/interact_with()
+	set name = "Interact With"
+	set desc = "Perform an interaction with someone."
+	set category = "IC"
+	set src in view(usr.client)
+
+	if(!usr.mind) //Mindless boys, honestly just don't, it's better this way
+		return
+	if(!usr.mind.interaction_holder)
+		usr.mind.interaction_holder = new(usr.mind)
+	usr.mind.interaction_holder.target = src.held_mob
+	usr.mind.interaction_holder.ui_interact(usr)

--- a/modular_sand/code/datums/interactions/interaction_interface.dm
+++ b/modular_sand/code/datums/interactions/interaction_interface.dm
@@ -3,7 +3,7 @@
 	set name = "Interact With"
 	set desc = "Perform an interaction with someone."
 	set category = "IC"
-	set src in view()
+	set src in view(usr.client)
 
 	if(!usr.mind) //Mindless boys, honestly just don't, it's better this way
 		return

--- a/modular_sand/code/modules/mob/living/living.dm
+++ b/modular_sand/code/modules/mob/living/living.dm
@@ -33,3 +33,4 @@
 			mob_size = MOB_SIZE_HUMAN
 		if(1.21 to INFINITY)
 			mob_size = MOB_SIZE_LARGE
+	SEND_SIGNAL(src, COMSIG_MOBSIZE_CHANGED, src)

--- a/modular_sand/code/modules/mob/living/living.dm
+++ b/modular_sand/code/modules/mob/living/living.dm
@@ -19,14 +19,17 @@
 		size_multiplier = new_size
 		resize = new_size / oldsize
 		update_transform()
-	switch(get_size(src))
-		if(0 to 40)
-			mob_size = MOB_SIZE_TINY
-		if(41 to 80)
-			mob_size = MOB_SIZE_SMALL
-		if(81 to 120)
-			mob_size = MOB_SIZE_HUMAN
-		if(121 to INFINITY)
-			mob_size = MOB_SIZE_LARGE
+		adjust_mobsize()
 
 	return TRUE
+
+/mob/living/proc/adjust_mobsize()
+	switch(get_size(src))
+		if(0 to 0.40)
+			mob_size = MOB_SIZE_TINY
+		if(0.41 to 0.80)
+			mob_size = MOB_SIZE_SMALL
+		if(0.81 to 1.20)
+			mob_size = MOB_SIZE_HUMAN
+		if(1.21 to INFINITY)
+			mob_size = MOB_SIZE_LARGE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3866,6 +3866,7 @@
 #include "modular_sand\code\controllers\subsystem\language.dm"
 #include "modular_sand\code\datums\action.dm"
 #include "modular_sand\code\datums\ai_laws.dm"
+#include "modular_sand\code\datums\dna.dm"
 #include "modular_sand\code\datums\shuttles.dm"
 #include "modular_sand\code\datums\components\mood.dm"
 #include "modular_sand\code\datums\components\riding.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so the mob_size actually gets updated when the mob spawns instead of only if their size gets changed during the game.
Makes you able to interact with mob holders and for people in mob holders to interact with you.
Still no idea how to make you able to examinate while being held though :(
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No need to drop people in your hands to continue your erp with them anymore.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
add: You can now interact with people you're holding in your hands!
fix: Makes the update_size proc actually give the mobs a valid mobsize instead of always 0
code: mob_size actually gets updated when a mob is spawned
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
