### PR TITLE
Adds an arousal button to the interaction ui (also does some ui "niceing")

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54057,11 +54057,11 @@
 	dir = 4
 	},
 /obj/item/clothing/gloves/color/latex{
-	step_y = 10
+	pixel_y = 10
 	},
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/clothing/mask/surgical{
-	step_y = -6
+	pixel_y = -6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -54097,11 +54097,11 @@
 	dir = 8
 	},
 /obj/item/clothing/gloves/color/latex{
-	step_y = 10
+	pixel_y = 10
 	},
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/clothing/mask/surgical{
-	step_y = -6
+	pixel_y = -6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)

--- a/modular_sand/code/datums/interactions/interaction_interface.dm
+++ b/modular_sand/code/datums/interactions/interaction_interface.dm
@@ -106,7 +106,7 @@
 			if(CHECK_BITFIELD(genital.genital_flags, GENITAL_INTERNAL))			//Not those though
 				continue
 			var/list/genital_entry = list()
-			genital_entry["name"] = "[genital.name]" //Prevents code from adding a prefix
+			genital_entry["name"] = "[capitalize(genital.name)]" //Prevents code from adding a prefix
 			genital_entry["key"] = REF(genital) //The key is the reference to the object
 			var/visibility = "Invalid"
 			if(CHECK_BITFIELD(genital.genital_flags, GENITAL_THROUGH_CLOTHES))
@@ -119,10 +119,15 @@
 				visibility = "Hidden by clothes"
 			genital_entry["visibility"] = visibility
 			genital_entry["possible_choices"] = GLOB.genitals_visibility_toggles
+			genital_entry["can_arouse"] = (
+				!!CHECK_BITFIELD(genital.genital_flags, GENITAL_CAN_AROUSE) \
+				&& !(HAS_TRAIT(get_genitals, TRAIT_PERMABONER) \
+				|| HAS_TRAIT(get_genitals, TRAIT_NEVERBONER)))
+			genital_entry["arousal_state"] = genital.aroused_state
 			genitals += list(genital_entry)
 	if(iscarbon(self))
 		var/simulated_ass = list()
-		simulated_ass["name"] = "anus"
+		simulated_ass["name"] = "Anus"
 		simulated_ass["key"] = "anus"
 		var/visibility = "Invalid"
 		switch(self.anus_exposed)
@@ -137,32 +142,32 @@
 		genitals += list(simulated_ass)
 	.["genitals"] = genitals
 
-	var/datum/preferences/prefs = usr?.client.prefs
+	var/datum/preferences/prefs = self?.client.prefs
 	if(prefs)
 	//Getting char prefs
 		.["erp_pref"] = 			pref_to_num(prefs.erppref)
-		.["noncon_pref"] = 		pref_to_num(prefs.nonconpref)
-		.["vore_pref"] = 		pref_to_num(prefs.vorepref)
+		.["noncon_pref"] = 			pref_to_num(prefs.nonconpref)
+		.["vore_pref"] = 			pref_to_num(prefs.vorepref)
 		.["extreme_pref"] = 		pref_to_num(prefs.extremepref)
 		.["extreme_harm"] = 		pref_to_num(prefs.extremeharm)
 
 	//Getting preferences
-		.["verb_consent"] = 		CHECK_BITFIELD(prefs.toggles, VERB_CONSENT)
+		.["verb_consent"] = 		!!CHECK_BITFIELD(prefs.toggles, VERB_CONSENT)
 		.["lewd_verb_sounds"] = 	!CHECK_BITFIELD(prefs.toggles, LEWD_VERB_SOUNDS)
 		.["arousable"] = 			prefs.arousable
-		.["genital_examine"] = 		CHECK_BITFIELD(prefs.cit_toggles, GENITAL_EXAMINE)
-		.["vore_examine"] = 		CHECK_BITFIELD(prefs.cit_toggles, VORE_EXAMINE)
-		.["medihound_sleeper"] =	CHECK_BITFIELD(prefs.cit_toggles, MEDIHOUND_SLEEPER)
-		.["eating_noises"] = 		CHECK_BITFIELD(prefs.cit_toggles, EATING_NOISES)
-		.["digestion_noises"] =		CHECK_BITFIELD(prefs.cit_toggles, DIGESTION_NOISES)
-		.["trash_forcefeed"] = 		CHECK_BITFIELD(prefs.cit_toggles, TRASH_FORCEFEED)
-		.["forced_fem"] = 			CHECK_BITFIELD(prefs.cit_toggles, FORCED_FEM)
-		.["forced_masc"] = 			CHECK_BITFIELD(prefs.cit_toggles, FORCED_MASC)
-		.["hypno"] = 				CHECK_BITFIELD(prefs.cit_toggles, HYPNO)
-		.["bimbofication"] = 		CHECK_BITFIELD(prefs.cit_toggles, BIMBOFICATION)
-		.["breast_enlargement"] = 	CHECK_BITFIELD(prefs.cit_toggles, BREAST_ENLARGEMENT)
-		.["penis_enlargement"] =	CHECK_BITFIELD(prefs.cit_toggles, PENIS_ENLARGEMENT)
-		.["butt_enlargement"] =		CHECK_BITFIELD(prefs.cit_toggles, BUTT_ENLARGEMENT)
+		.["genital_examine"] = 		!!CHECK_BITFIELD(prefs.cit_toggles, GENITAL_EXAMINE)
+		.["vore_examine"] = 		!!CHECK_BITFIELD(prefs.cit_toggles, VORE_EXAMINE)
+		.["medihound_sleeper"] =	!!CHECK_BITFIELD(prefs.cit_toggles, MEDIHOUND_SLEEPER)
+		.["eating_noises"] = 		!!CHECK_BITFIELD(prefs.cit_toggles, EATING_NOISES)
+		.["digestion_noises"] =		!!CHECK_BITFIELD(prefs.cit_toggles, DIGESTION_NOISES)
+		.["trash_forcefeed"] = 		!!CHECK_BITFIELD(prefs.cit_toggles, TRASH_FORCEFEED)
+		.["forced_fem"] = 			!!CHECK_BITFIELD(prefs.cit_toggles, FORCED_FEM)
+		.["forced_masc"] = 			!!CHECK_BITFIELD(prefs.cit_toggles, FORCED_MASC)
+		.["hypno"] = 				!!CHECK_BITFIELD(prefs.cit_toggles, HYPNO)
+		.["bimbofication"] = 		!!CHECK_BITFIELD(prefs.cit_toggles, BIMBOFICATION)
+		.["breast_enlargement"] = 	!!CHECK_BITFIELD(prefs.cit_toggles, BREAST_ENLARGEMENT)
+		.["penis_enlargement"] =	!!CHECK_BITFIELD(prefs.cit_toggles, PENIS_ENLARGEMENT)
+		.["butt_enlargement"] =		!!CHECK_BITFIELD(prefs.cit_toggles, BUTT_ENLARGEMENT)
 		.["never_hypno"] = 			!CHECK_BITFIELD(prefs.cit_toggles, NEVER_HYPNO)
 		.["no_aphro"] = 			!CHECK_BITFIELD(prefs.cit_toggles, NO_APHRO)
 		.["no_ass_slap"] = 			!CHECK_BITFIELD(prefs.cit_toggles, NO_ASS_SLAP)
@@ -189,13 +194,34 @@
 			return FALSE
 		if("genital")
 			var/mob/living/carbon/self = usr
-			if(params["genital"] == "anus")
-				self.anus_toggle_visibility(params["visibility"])
-				return TRUE
-			var/obj/item/organ/genital/genital = locate(params["genital"], self.internal_organs)
-			if(genital && (genital in self.internal_organs))
-				genital.toggle_visibility(params["visibility"])
-				return TRUE
+			if("visibility" in params)
+				if(params["genital"] == "anus")
+					self.anus_toggle_visibility(params["visibility"])
+					return TRUE
+				var/obj/item/organ/genital/genital = locate(params["genital"], self.internal_organs)
+				if(genital && (genital in self.internal_organs))
+					genital.toggle_visibility(params["visibility"])
+					return TRUE
+			if("set_arousal" in params)
+				var/obj/item/organ/genital/genital = locate(params["genital"], self.internal_organs)
+				if(!genital || (genital \
+					&& (!CHECK_BITFIELD(genital.genital_flags, GENITAL_CAN_AROUSE) \
+					|| HAS_TRAIT(self, TRAIT_PERMABONER) \
+					|| HAS_TRAIT(self, TRAIT_NEVERBONER))))
+					return FALSE
+				var/original_state = genital.aroused_state
+				genital.set_aroused_state(params["set_arousal"])// i'm not making it just `!aroused_state` because
+				if(original_state != genital.aroused_state)		// someone just might port skyrat's new genitals
+					to_chat(self, "<span class='userlove'>[genital.aroused_state ? genital.arousal_verb : genital.unarousal_verb].</span>")
+					. = TRUE
+				else
+					to_chat(self, "<span class='userlove'>You can't make that genital [genital.aroused_state ? "unaroused" : "aroused"]!</span>")
+					. = FALSE
+				genital.update_appearance()
+				if(ishuman(self))
+					var/mob/living/carbon/human/human = self
+					human.update_genitals()
+				return
 			else
 				return FALSE
 		if("char_pref")

--- a/tgui/packages/tgui/interfaces/MobInteraction.tsx
+++ b/tgui/packages/tgui/interfaces/MobInteraction.tsx
@@ -3,6 +3,7 @@ import { flow } from 'common/fp';
 import { createSearch } from 'common/string';
 import { useBackend, useLocalState } from '../backend';
 import { BlockQuote, Button, Flex, LabeledList, Icon, Input, Section, Table, Tabs, Stack } from '../components';
+import { TableCell, TableRow } from '../components/Table';
 import { Window } from '../layouts';
 
 type HeaderInfo = {
@@ -31,6 +32,8 @@ type GenitalData = {
   key: string,
   visibility: string,
   possible_choices: string[],
+  can_arouse: boolean,
+  arousal_state: boolean,
 }
 
 type CharacterPrefsInfo = {
@@ -42,26 +45,26 @@ type CharacterPrefsInfo = {
 }
 
 type ContentPrefsInfo = {
-  verb_consent: number,
-  lewd_verb_sounds: number,
-  arousable: number,
-  genital_examine: number,
-  vore_examine: number,
-  medihound_sleeper: number,
-  eating_noises: number,
-  digestion_noises: number,
-  trash_forcefeed: number,
-  forced_fem: number,
-  forced_masc: number,
-  hypno: number,
-  bimbofication: number,
-  breast_enlargement: number,
-  penis_enlargement: number,
-  butt_enlargement: number,
-  never_hypno: number,
-  no_aphro: number,
-  no_ass_slap: number,
-  no_auto_wag: number,
+  verb_consent: boolean,
+  lewd_verb_sounds: boolean,
+  arousable: boolean,
+  genital_examine: boolean,
+  vore_examine: boolean,
+  medihound_sleeper: boolean,
+  eating_noises: boolean,
+  digestion_noises: boolean,
+  trash_forcefeed: boolean,
+  forced_fem: boolean,
+  forced_masc: boolean,
+  hypno: boolean,
+  bimbofication: boolean,
+  breast_enlargement: boolean,
+  penis_enlargement: boolean,
+  butt_enlargement: boolean,
+  never_hypno: boolean,
+  no_aphro: boolean,
+  no_ass_slap: boolean,
+  no_auto_wag: boolean,
 }
 
 export const MobInteraction = (props, context) => {
@@ -107,12 +110,12 @@ export const MobInteraction = (props, context) => {
           </Table>
         </Section>
         <Section>
-          <Tabs>
+          <Tabs fluid textAlign="center">
             <Tabs.Tab selected={tabIndex === 0} onClick={() => setTabIndex(0)}>
               Interactions
             </Tabs.Tab>
             <Tabs.Tab selected={tabIndex === 1} onClick={() => setTabIndex(1)}>
-              Genital Visibility
+              Genital Options
             </Tabs.Tab>
             <Tabs.Tab selected={tabIndex === 2} onClick={() => setTabIndex(2)}>
               Character Prefs
@@ -124,7 +127,7 @@ export const MobInteraction = (props, context) => {
           {tabIndex === 0 && (
             <InteractionsTab />
           ) || tabIndex === 1 && (
-            <GenitalVisibilityTab />
+            <GenitalTab />
           ) || tabIndex === 2 && (
             <CharacterPrefsTab />
           ) || tabIndex === 3 && (
@@ -213,29 +216,59 @@ const ModeToIcon = {
   "Always hidden": "eye-slash",
 };
 
-const GenitalVisibilityTab = (props, context) => {
+/*
+  Greetings you, yes you, adding more stuff to actions,
+  To not have as much headache as i did,
+  do not attempt to make a sum of 100% with the buttons
+  as it will mess up math somewhere and overflow.
+
+  Also this is adjusted only for the current size,
+  if anyone feels like shrinking,
+  their window it will overflow anyways.
+  Single items is fine.
+*/
+const GenitalTab = (props, context) => {
   const { act, data } = useBackend<GenitalInfo>(context);
   const genitals = data.genitals || [];
   return (
     genitals.length ? (
       <Flex direction="column">
-        <LabeledList>
-          {genitals.map(genital => (
-            <LabeledList.Item key={genital.key} label={genital.name}>
-              {genital.possible_choices.map(choice => (
+        {genitals.map(genital => (
+          <Section key={genital.key} title={genital.name} textAlign="center">
+            <Table>
+              <TableCell width="50%" textAlign="center">
+                Visibility<br />
+                {genital.possible_choices.map(choice => (
+                  <Button
+                    width={((1 / genital.possible_choices.length) * 97) + "%"}
+                    key={choice}
+                    tooltip={choice}
+                    icon={ModeToIcon[choice]}
+                    color={genital.visibility === choice ? "green" : "default"}
+                    onClick={() => act('genital', {
+                      genital: genital.key,
+                      visibility: choice,
+                    })} />
+                ))}
+              </TableCell>
+              <TableCell textAlign="center">
+                Actions<br />
                 <Button
-                  key={choice}
-                  tooltip={choice}
-                  icon={ModeToIcon[choice]}
-                  color={genital.visibility === choice ? "green" : "default"}
+                  width="100%"
+                  key={genital.arousal_state}
+                  tooltip={genital.can_arouse
+                    ? ((genital.arousal_state ? "Unarouse" : "Arouse") + " your " + genital.name.toLowerCase())
+                    : "You cannot modify arousal on your " + genital.name.toLowerCase()}
+                  icon="heart"
+                  color={genital.can_arouse ? (genital.arousal_state ? "green" : "default") : "grey"}
                   onClick={() => act('genital', {
                     genital: genital.key,
-                    visibility: choice,
+                    set_arousal: !genital.arousal_state,
                   })} />
-              ))}
-            </LabeledList.Item>
-          ))}
-        </LabeledList>
+              </TableCell>
+            </Table>
+          </Section>
+        ))}
       </Flex>
     ) : (
       <Section align="center">


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The verbs for handling genitals still suck, this does something so you don't have to touch them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a nice little feature.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
tweak: Interaction's tabs are now centered and fluid, getting a better look overrall.
qol: Arousal can now be toggled on the interaction ui, check the renamed tab "genital options".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
