### PR TITLE
Fix late-join panel job slot numbers

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -594,7 +594,7 @@
 				if(job in GLOB.command_positions)
 					command_bold = " command"
 				//Sandstorm changes
-				var/jobline = "[job_datum.title] ([job_datum.current_positions])"
+				var/jobline = "[job_datum.title]"
 				if(job_datum in SSjob.prioritized_jobs)
 					jobline = "<span class='priority'>[jobline]</span>"
 				if(client && client.prefs && client.prefs.alt_titles_preferences[job_datum.title])


### PR DESCRIPTION
## About The Pull Request
Fixes a redundant display of job slots on the latejoin panel.
Caused by https://github.com/Citadel-Station-13/Citadel-Station-13/pull/15919

![latejoin_slots_number_bugged](https://user-images.githubusercontent.com/5933805/211487022-b6d351fd-b79a-44fa-a3b1-54ed06092090.png)
(This is what is being fixed)

## Why It's Good For The Game
Code should function properly.

## A Port?
No.

## Changelog
:cl:
fix: Fixed the late-join panel showing job slots twice
/:cl: