### PR TITLE
Minor techweb fix for autodoc

### DIFF
--- a/modular_sand/code/modules/research/techweb/nodes/all_nodes.dm
+++ b/modular_sand/code/modules/research/techweb/nodes/all_nodes.dm
@@ -31,7 +31,7 @@
 	design_ids = list("ci-toolset-adv","ci-surgery-adv")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
-/datum/techweb_node/adv_surgery/New()
+/datum/techweb_node/advance_surgerytools/New()
 	design_ids += "autodoc"
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request
Moves the Autodoc from Advanced Surgery to Advanced Surgery Tools, since it cannot be constructed without the items from that node. Specifically, the _searing tool_ and _mechanical pinches_ are both required, but are unavailable without further research.

![medical_advtools_node](https://user-images.githubusercontent.com/5933805/212830593-7906ae52-a8f7-4658-936f-bcb1c20b35e0.png)

## Why It's Good For The Game
Prevents unlocking a machine before it can be constructed, which can be a source of confusion.

## A Port?
No.

## Changelog
:cl:
tweak: Moved Autodoc techweb entry from Advanced Surgery to Advanced Surgery Tools
/:cl: