### PR TITLE
Require bluespace core for BSMs

### DIFF
--- a/modular_sand/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/modular_sand/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -40,7 +40,7 @@
 		/obj/item/stock_parts/micro_laser = 5,
 		/obj/item/stock_parts/manipulator = 5,
 		/obj/item/stock_parts/scanning_module = 5,
-		/obj/item/stack/ore/bluespace_crystal = 5)
+		ANOMALY_CORE_BLUESPACE = 1)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/telecomms/message_server

--- a/modular_sand/code/modules/research/techweb/nodes/bluespace_nodes.dm
+++ b/modular_sand/code/modules/research/techweb/nodes/bluespace_nodes.dm
@@ -33,8 +33,8 @@
 /datum/techweb_node/bs_mining
 	id = "bluespace_mining"
 	display_name = "Bluespace Mining Technology"
-	description = "Harness the power of bluespace to make materials out of nothing. Slowly."
-	prereq_ids = list("practical_bluespace", "adv_mining")
+	description = "Harness the power of bluespace to make materials out of nothing, slowly. Requires a bluespace core to function."
+	prereq_ids = list("practical_bluespace", "adv_mining", "anomaly_research")
 	design_ids = list("bluespace_miner")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 


### PR DESCRIPTION
## About The Pull Request
Updates bluespace miners construction and techweb requirements. Made at the request of user _SandPoot_.

- Added construction requirement of activated bluespace core
- Added techweb requirement for Anomaly Research
- Removed construction requirement of bluespace crystals

## Why It's Good For The Game
Bluespace miners can be used to trivialize the game's resource gathering and management systems early into a round. Increasing the requirement, without completely removing it, serves to delay the time before station resources are effectively infinite.

## A Port?
No.

## Changelog
:cl:
tweak: Bluespace mining research is now behind Anomaly Research
balance: Bluespace miners now require a bluespace anomaly core
/:cl: