### PR TITLE
Monophobia vore and blind fix

### DIFF
--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -171,9 +171,14 @@
 		stress = max(stress - 4, 0)
 
 /datum/brain_trauma/severe/monophobia/proc/check_alone()
+//SANDSTORM EDIT
+	var/check_radius = 7
+	if(istype(owner.loc, /obj/belly))
+		return FALSE
 	if(HAS_TRAIT(owner, TRAIT_BLIND))
-		return TRUE
-	for(var/mob/M in oview(owner, 7))
+		check_radius = 1
+	for(var/mob/M in oview(owner, check_radius))
+//SANDSTORM EDIT END
 		if(!isliving(M)) //ghosts ain't people
 			continue
 		if((istype(M, /mob/living/simple_animal/pet)) || M.ckey)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Doll with monophobia trauma dont die in someones belly from heart attack (same with just blinded doll (need someone in 1 tile radius)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Die in someone just with reason "alone" and same thing while you blinded and someone hugs you, but you dies from being "alone" and other other other rp breaking moments.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl: Winter Schock
fix: Doll with monophobia dont get stress in someone vore belly 
fix: Blind doll with monophobia dont get stress while someone in 1 tile range 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
