### PR TITLE
[PORT] New quirk: DNC Order

### DIFF
--- a/code/__SANDCODE/DEFINES/traits.dm
+++ b/code/__SANDCODE/DEFINES/traits.dm
@@ -6,3 +6,5 @@
 #define TRAIT_SHELTERED			"sheltered"
 /// Define for the quirk "infertile", self explanatory. Please make this a preference on the Content Preferences Tab.
 #define TRAIT_INFERTILE			"infertile"
+/// DNC trait, used to prevent cloning
+#define TRAIT_DNC_ORDER			"dnc_order"

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -502,6 +502,12 @@
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 
 /obj/machinery/computer/cloning/proc/can_scan(datum/dna/dna, mob/living/mob_occupant, experimental = FALSE, datum/bank_account/account)
+	// Sandstorm edit: Check for DNC Order quirk
+	if(HAS_TRAIT(mob_occupant, TRAIT_DNC_ORDER))
+		scantemp = "Subject has an active DNC order on file. Further operations terminated."
+		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+		return
+	// End Sandstorm edit
 	if(!istype(dna))
 		scantemp = "Unable to locate valid genetic data."
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -502,12 +502,6 @@
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 
 /obj/machinery/computer/cloning/proc/can_scan(datum/dna/dna, mob/living/mob_occupant, experimental = FALSE, datum/bank_account/account)
-	// Sandstorm edit: Check for DNC Order quirk
-	if(HAS_TRAIT(mob_occupant, TRAIT_DNC_ORDER))
-		scantemp = "Subject has an active DNC order on file. Further operations terminated."
-		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
-		return
-	// End Sandstorm edit
 	if(!istype(dna))
 		scantemp = "Unable to locate valid genetic data."
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -94,6 +94,10 @@
 		C.dna.copy_dna(brainmob.stored_dna)
 		if(HAS_TRAIT(L, TRAIT_NOCLONE))
 			LAZYSET(brainmob.status_traits, TRAIT_NOCLONE, L.status_traits[TRAIT_NOCLONE])
+		// Sandstorm edit: DNC Order quirk
+		if(HAS_TRAIT(L, TRAIT_DNC_ORDER))
+			LAZYSET(brainmob.status_traits, TRAIT_DNC_ORDER, L.status_traits[TRAIT_DNC_ORDER])
+		// End Sandstorm edit
 		var/obj/item/organ/zombie_infection/ZI = L.getorganslot(ORGAN_SLOT_ZOMBIE)
 		if(ZI)
 			brainmob.set_species(ZI.old_species)	//For if the brain is cloned

--- a/modular_sand/code/datums/traits/negative.dm
+++ b/modular_sand/code/datums/traits/negative.dm
@@ -15,3 +15,10 @@
 /datum/quirk/sheltered/remove() //i mean, the lose text explains it, so i'm making it actually work
 	var/mob/living/carbon/human/H = quirk_holder
 	H.grant_language(/datum/language/common)
+
+/datum/quirk/dnc_order
+	name = "DNC Order"
+	desc = "You have a Do Not Clone order on your record, stating that you may not be cloned. You can still be revived by other means."
+	value = -2
+	mob_trait = TRAIT_DNC_ORDER
+	medical_record_text = "Patient has a DNC (Do Not Clone) order and will be rejected by cloning mechanisms as a result."

--- a/modular_sand/code/game/machinery/computer/cloning.dm
+++ b/modular_sand/code/game/machinery/computer/cloning.dm
@@ -1,0 +1,15 @@
+// Proc for scanning a mob in a cloning machine
+/obj/machinery/computer/cloning/can_scan(datum/dna/dna, mob/living/mob_occupant, experimental = FALSE, datum/bank_account/account)
+	// Check for DNC Order quirk
+	if(HAS_TRAIT(mob_occupant, TRAIT_DNC_ORDER))
+		// Set scan failure reason
+		scantemp = "Subject has an active DNC order on file. Further operations terminated."
+
+		// Play error sound
+		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+
+		// Return without scanning
+		return
+
+	// Return normally
+	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3965,6 +3965,7 @@
 #include "modular_sand\code\game\machinery\cryopod.dm"
 #include "modular_sand\code\game\machinery\cryptominers.dm"
 #include "modular_sand\code\game\machinery\Sleeper.dm"
+#include "modular_sand\code\game\machinery\computer\cloning.dm"
 #include "modular_sand\code\game\machinery\computer\arcade\tetris.dm"
 #include "modular_sand\code\game\machinery\pipe\construction.dm"
 #include "modular_sand\code\game\machinery\telecomms\machine_interactions.dm"


### PR DESCRIPTION
## About The Pull Request
Ports the do-not-clone quirk from SPLURT. Like the original; This change is not modular.

The following changes are made from the original:
- Added a fix for cloning heads and brains
- Removed flavor text implications that the order was voluntary
- Quirk renamed from `DNC` to `DNC Order`
- Trait renamed from `TRAIT_NO_CLONE` to `TRAIT_DNC_ORDER`

This port made at the request of user SandPoot.

## Why It's Good For The Game
Allows crew to reject the cloning system for mechanical or lore reasons, while also being rewarded with quirk points for doing so.

## A Port?
Yes: Ported from SPLURT Station 13.
The original commit can be found here: https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/commit/561831bde308290a17fbd54774e57c83b8d2934a

## Changelog
:cl:
add: Added quirk: DNC Order
/:cl: