### PR TITLE
Convert Saliith plushie to Headcoder plushie

### DIFF
--- a/modular_sand/code/_globalvars/lists/objects.dm
+++ b/modular_sand/code/_globalvars/lists/objects.dm
@@ -1,3 +1,3 @@
 GLOBAL_LIST_EMPTY(ic_jammers)
 GLOBAL_LIST_EMPTY(ic_speakers)
-GLOBAL_DATUM_INIT(saliith_plushie, /obj/item/toy/plush/lizardplushie/saliith, new)
+GLOBAL_DATUM_INIT(plushie_headcoder, /obj/item/toy/plush/headcoder, new)

--- a/modular_sand/code/game/objects/items/plushes.dm
+++ b/modular_sand/code/game/objects/items/plushes.dm
@@ -1,7 +1,10 @@
-// Honestly, Saliith was just sad when he made this. Leave this file in the game to let people hug him.
+// Honestly, Saliith was just sad when he made the original. Leave this file in the game to carry on his legacy.
 
-/obj/item/toy/plush/lizardplushie/saliith
-	name = "Saliith plushie"
+// BYOND ckey for plushie owner
+#define PLUSH_HEADCODER_CKEY "sandpoot"
+
+/obj/item/toy/plush/headcoder
+	name = "saliith plushie"
 	desc = "He looks like he needs a friend."
 	icon = 'modular_sand/icons/obj/plushes.dmi'
 	icon_state = "saliith"
@@ -9,16 +12,18 @@
 	can_random_spawn = FALSE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF // Protected by a higher power
 	unstuffable = TRUE // Prevent grenades
+	squeak_override = list('modular_citadel/sound/voice/hiss.ogg'=1)
+	attack_verb = list("clawed", "hissed", "tail slapped")
 
-/obj/item/toy/plush/lizardplushie/saliith/Initialize(mapload, set_snowflake_id)
+/obj/item/toy/plush/headcoder/Initialize(mapload, set_snowflake_id)
 	// Check if plush already exists
-	if(GLOB.saliith_plushie && (GLOB.saliith_plushie != src))
+	if(GLOB.plushie_headcoder && (GLOB.plushie_headcoder != src))
 		return INITIALIZE_HINT_QDEL
 
 	// Return normally
 	. = ..()
 
-/obj/item/toy/plush/lizardplushie/saliith/ComponentInitialize()
+/obj/item/toy/plush/headcoder/ComponentInitialize()
 	. = ..()
 
 	// Add respawn component
@@ -31,7 +36,7 @@
 	// Add custom description
 	normal_desc = "[p_they] look[p_s] like [p_they] need[p_s] a friend."
 
-/obj/item/toy/plush/lizardplushie/saliith/examine(mob/user)
+/obj/item/toy/plush/headcoder/examine(mob/user)
 	. = ..()
 
 	// Define pronouns
@@ -45,8 +50,8 @@
 		. += span_deadsay("[p_they(TRUE)] [p_are()] dead.")
 		return
 
-	// Check if user is Saliith himself
-	if(user.ckey == "sandpoot")
+	// Check if user is Headcoder
+	if(user.ckey == PLUSH_HEADCODER_CKEY)
 		// Update examine text and return
 		. += span_deadsay("You feel a sense of familiarity from [p_them].")
 		return
@@ -56,7 +61,7 @@
 		// Update examine text
 		. += span_warning("[src] gives you a menacing glare! Patting [p_them] would be a dangerous mistake.")
 
-/obj/item/toy/plush/lizardplushie/saliith/attack_self(mob/living/carbon/human/user)
+/obj/item/toy/plush/headcoder/attack_self(mob/living/carbon/human/user)
 	// Check if user exists
 	if(!user)
 		// Return normally
@@ -68,14 +73,14 @@
 		return ..()
 
 	// Define pronouns
-	var/p_they = p_they()
+	//var/p_they = p_they()
 	//var/p_their = p_their()
-	var/p_s = p_s()	
+	//var/p_s = p_s()	
 
-	// Check if user is Saliith himself
-	if(user.ckey == "sandpoot")
+	// Check if user is Headcoder
+	if(user.ckey == PLUSH_HEADCODER_CKEY)
 		// Alert him and return
-		to_chat(user, span_notice("[p_they] give[p_s] you a hesitant gaze, but accept[p_s] the gesture anyhow."))
+		to_chat(user, span_notice("[src] gives you a hesitant gaze, but accepts the gesture anyhow."))
 		return ..()
 
 	// Check if user is an antagonist role
@@ -117,12 +122,12 @@
 	// User has no antagonist status
 
 	// Alert the user
-	to_chat(user, span_notice("[p_they] give[p_s] you a hesitant gaze, but accepts the gesture anyhow."))
+	to_chat(user, span_notice("[src] gives you a hesitant gaze, but accepts the gesture anyhow."))
 
 	// Return
 	return ..()
 
-/obj/item/toy/plush/lizardplushie/saliith/attackby(obj/item/item_used, mob/living/user, params)
+/obj/item/toy/plush/headcoder/attackby(obj/item/item_used, mob/living/user, params)
 	// Check for sharp object
 	if(item_used.get_sharpness())
 		// Warn in local chat
@@ -137,8 +142,8 @@
 		// Return
 		return
 
-	// Check if user is Saliith himself
-	if(user.ckey == "sandpoot")
+	// Check if user is Headcoder
+	if(user.ckey == PLUSH_HEADCODER_CKEY)
 		// Return with no effects
 		return ..()
 
@@ -162,12 +167,12 @@
 	// Return normally
 	return ..()
 
-/obj/item/toy/plush/lizardplushie/saliith/ex_act(severity, target, origin)
+/obj/item/toy/plush/headcoder/ex_act(severity, target, origin)
 	return
 
 /obj/item/toy/plush/plushling/plushie_absorb(obj/item/toy/plush/victim)
-	// Check if target is the Saliith plushie
-	if(istype(victim, /obj/item/toy/plush/lizardplushie/saliith))
+	// Check if target is the Headcoder plushie
+	if(istype(victim, /obj/item/toy/plush/headcoder))
 		// Warn in local chat
 		visible_message(span_warning("[victim] violently parries the impostor! [src] is utterly annihilated!"))
 
@@ -185,16 +190,16 @@
 
 /obj/item/toy/plush/love(obj/item/toy/plush/Kisser, mob/living/user)
 	// Define saliith plush
-	var/plush_saliith = /obj/item/toy/plush/lizardplushie/saliith
+	var/plush_saliith = /obj/item/toy/plush/headcoder
 
-	// Check if interaction involves the Saliith plush
+	// Check if interaction involves the Headcoder plush
 	if(istype(src, plush_saliith) || istype(Kisser, plush_saliith))
-		// Check if user is Saliith himself
-		if(user.ckey == "sandpoot")
+		// Check if user is Headcoder
+		if(user.ckey == PLUSH_HEADCODER_CKEY)
 			// Return normally
 			return ..()
 
-		// User is not Saliith
+		// User is not Headcoder
 		// Warn in local chat
 		user.visible_message(span_warning("[user] tried to force [Kisser] to kiss [src] against their will, and has been yeeted!"), span_warning("You try to force [Kisser] to kiss [src], but get yeeted instead!"))
 
@@ -218,16 +223,16 @@
 		// Return
 		return
 
-	// Interaction does not involve Saliith
+	// Interaction does not involve Headcoder
 	// Return normally
 	return ..()
 
 // Pinpointer for plushie toy
-/obj/item/pinpointer/plushie_saliith 
-	name = "Saliith plushie pinpointer"
-	desc = "A handheld tracking device that locates Saliith's plushie."
+/obj/item/pinpointer/plushie_headcoder 
+	name = "Secret plushie pinpointer"
+	desc = "A handheld tracking device that locates the secret plushie."
 	icon = 'modular_sand/icons/obj/device.dmi'
 	icon_state = "pinpointer_saliith"
 
-/obj/item/pinpointer/plushie_saliith/scan_for_target()
-	set_target(GLOB.saliith_plushie, src)
+/obj/item/pinpointer/plushie_headcoder/scan_for_target()
+	set_target(GLOB.plushie_headcoder, src)

--- a/modular_sand/code/modules/client/loadout/backpack.dm
+++ b/modular_sand/code/modules/client/loadout/backpack.dm
@@ -1,3 +1,3 @@
-/datum/gear/backpack/pinpointer/plushie_saliith
-	name = "Saliith Plushie Pinpointer"
-	path = /obj/item/pinpointer/plushie_saliith
+/datum/gear/backpack/pinpointer/plushie_headcoder
+	name = "Secret Plushie Pinpointer"
+	path = /obj/item/pinpointer/plushie_headcoder

--- a/modular_sand/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
+++ b/modular_sand/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
@@ -3,7 +3,7 @@
 	// Check for Headcoder plush
 	if(istype(O, /obj/item/toy/plush/headcoder))
 		// Warn in local chat
-		O.loc.visible_message(span_warning("[src] is sprayed with a strange chemical, and vanishes in a puff of smoke!"))
+		O.loc.visible_message(span_warning("[O] is sprayed with a strange chemical, and vanishes in a puff of smoke!"))
 
 		// Create an impostor plush
 		new /obj/item/toy/plush/mammal(O.loc)

--- a/modular_sand/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
+++ b/modular_sand/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
@@ -1,7 +1,7 @@
 // Plushmium object reaction
 /datum/reagent/fermi/plushmium/reaction_obj(obj/O, reac_volume)
-	// Check for Saliith plush
-	if(istype(O, /obj/item/toy/plush/lizardplushie/saliith))
+	// Check for Headcoder plush
+	if(istype(O, /obj/item/toy/plush/headcoder))
 		// Check if a carbon user exists
 		if((!usr) || (!iscarbon(usr)))
 			// Return without any effects

--- a/modular_sand/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
+++ b/modular_sand/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
@@ -2,24 +2,17 @@
 /datum/reagent/fermi/plushmium/reaction_obj(obj/O, reac_volume)
 	// Check for Headcoder plush
 	if(istype(O, /obj/item/toy/plush/headcoder))
-		// Check if a carbon user exists
-		if((!usr) || (!iscarbon(usr)))
-			// Return without any effects
-			return
-
 		// Warn in local chat
-		O.loc.visible_message(span_warning("[src] is sprayed with a strange chemical, and reacts with overwhelming hostility! [usr] is sprayed with a concoction of horrible chemicals!"))
+		O.loc.visible_message(span_warning("[src] is sprayed with a strange chemical, and vanishes in a puff of smoke!"))
 
-		// Define user mob
-		var/mob/living/carbon/human/spray_user = usr
+		// Create an impostor plush
+		new /obj/item/toy/plush/mammal(O.loc)
 
-		// Add chemicals
-		spray_user.reagents.add_reagent(/datum/reagent/toxin/mutagen, 20)
-		spray_user.reagents.add_reagent(/datum/reagent/toxin/mindbreaker, 20)
-		spray_user.reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 20)
-		//spray_user.reagents.add_reagent(/datum/reagent/toxin/histamine, 30)
-		spray_user.reagents.add_reagent(/datum/reagent/toxin/bonehurtingjuice, 30)
-		spray_user.reagents.add_reagent(/datum/reagent/toxin/brainhurtingjuice, 30)
+		// Create a smoke effect
+		new /obj/effect/temp_visual/small_smoke(O.loc)
+
+		// Send the real plush to a safe location
+		O.forceMove(find_safe_turf())
 
 		// Return without further effects
 		return


### PR DESCRIPTION
## About The Pull Request
Replaces the static Saliith plushie with a more dynamic variant that can be edited to represent other figures.

- Adds a define for what ckey to use
- Adds squeak override sound
- Adds attack verb definitions
- Replaces all coded instances of Saliith with Headcoder
- Replaces plushmium chem reaction with an escape ninjitsu
- Renames "Saliith plushie pinpointer" to "Secret plushie pinpointer"

## Why It's Good For The Game
Allows downstream server owners to customize the unique plushie.

## A Port?
No.

## Changelog
:cl:
tweak: Saliith plushie now hisses
tweak: Saliith plushie pinpointer renamed to Secret plushie pinpointer
balance: Saliith plushie is no longer filled with toxins, but has taken up ninjitsu
code: Saliith plushie is now Headcoder plushie
code: Added a defines for Headcoder plushie ckey
/:cl: