### PR TITLE
Adds a preference for macro stomping

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1219,6 +1219,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(extremepref != "No")
 				dat += "<b><span style='color: #e60000;'>Harmful ERP verbs :</b> <a href='?_src_=prefs;preference=extremeharm'>[extremeharm]</a><br>"
 			//END OF SKYRAT EDIT
+			// SANDSTORM EDIT
+			dat += "<b>Macro Stomping:</b> <a href='?_src_=prefs;preference=pref_stomping'>[pref_stomping]</a><br>" 
+			// END OF SANDSTORM EDIT
 			dat += "<b>Automatic Wagging:</b> <a href='?_src_=prefs;preference=auto_wag'>[(cit_toggles & NO_AUTO_WAG) ? "Disabled" : "Enabled"]</a><br>"
 			dat += "</tr></table>"
 			dat += "<br>"
@@ -2962,6 +2965,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					if(extremepref == "No")
 						extremeharm = "No"
 				//END CITADEL EDIT
+				// Sandstorm edit
+				if("pref_stomping")
+					switch(pref_stomping)
+						if("Yes")
+							pref_stomping = "No"
+						if("No")
+							pref_stomping = "Yes"
+				// End sandstorm edit
 				if("publicity")
 					if(unlock_content)
 						toggles ^= MEMBER_PUBLIC

--- a/modular_sand/code/modules/client/preferences.dm
+++ b/modular_sand/code/modules/client/preferences.dm
@@ -1,3 +1,7 @@
+// New preference entries
+/datum/preferences
+	var/pref_stomping = "Yes"
+
 //SKYRAT EDIT - extra language
 /datum/preferences/proc/SetLanguage(mob/user)
 	var/list/dat = list()

--- a/modular_sand/code/modules/client/preferences.dm
+++ b/modular_sand/code/modules/client/preferences.dm
@@ -1,6 +1,6 @@
 // New preference entries
 /datum/preferences
-	var/pref_stomping = "Yes"
+	var/pref_stomping = "No"
 
 //SKYRAT EDIT - extra language
 /datum/preferences/proc/SetLanguage(mob/user)

--- a/modular_sand/code/modules/client/preferences_savefile.dm
+++ b/modular_sand/code/modules/client/preferences_savefile.dm
@@ -22,4 +22,4 @@
 	. = ..()
 
 	// Load modular prefs
-	pref_stomping = sanitize_inlist(S["pref_stomping"], GLOB.lewd_prefs_choices, "Yes")
+	pref_stomping = sanitize_inlist(S["pref_stomping"], GLOB.lewd_prefs_choices, "No")

--- a/modular_sand/code/modules/client/preferences_savefile.dm
+++ b/modular_sand/code/modules/client/preferences_savefile.dm
@@ -19,4 +19,7 @@
 	. = ..()
 
 /datum/preferences/cit_character_pref_load(savefile/S)
+	. = ..()
+
+	// Load modular prefs
 	pref_stomping = sanitize_inlist(S["pref_stomping"], GLOB.lewd_prefs_choices, "Yes")

--- a/modular_sand/code/modules/client/preferences_savefile.dm
+++ b/modular_sand/code/modules/client/preferences_savefile.dm
@@ -17,3 +17,6 @@
 			DISABLE_BITFIELD(toggles, SOUND_BARK)
 			ENABLE_BITFIELD(toggles, VERB_CONSENT)
 	. = ..()
+
+/datum/preferences/cit_character_pref_load(savefile/S)
+	pref_stomping = sanitize_inlist(S["pref_stomping"], GLOB.lewd_prefs_choices, "Yes")

--- a/modular_sand/code/modules/resize/resizing.dm
+++ b/modular_sand/code/modules/resize/resizing.dm
@@ -60,6 +60,11 @@
 			return TRUE
 
 		if(abs(get_size(user)/get_size(target)) >= 2)
+			// Check client pref
+			if(target.client?.prefs.pref_stomping != "Yes")
+				// Prevent stomp
+				return FALSE
+
 			log_combat(user, target, "stepped on", addition="[user.a_intent] trample")
 			if(user.a_intent == "disarm" && CHECK_MOBILITY(user, MOBILITY_MOVE) && !user.buckled)
 				now_pushing = 0

--- a/modular_sand/code/modules/resize/resizing.dm
+++ b/modular_sand/code/modules/resize/resizing.dm
@@ -62,8 +62,13 @@
 		if(abs(get_size(user)/get_size(target)) >= 2)
 			// Check client pref
 			if(target.client?.prefs.pref_stomping != "Yes")
-				// Prevent stomp
-				return FALSE
+				// Warn in chat
+				target.visible_message(span_danger("[src] is attempting to step on [target]!"), span_danger("[src] is attempting to step on you!"))
+
+				// Perform interaction timer
+				if(!do_mob(user, target, 3 SECONDS))
+					// Prevent stomp
+					return FALSE
 
 			log_combat(user, target, "stepped on", addition="[user.a_intent] trample")
 			if(user.a_intent == "disarm" && CHECK_MOBILITY(user, MOBILITY_MOVE) && !user.buckled)
@@ -80,6 +85,10 @@
 					return TRUE
 
 			if(user.a_intent == "harm" && CHECK_MOBILITY(user, MOBILITY_MOVE) && !user.buckled)
+				// Check client pref for harm
+				if(target.client?.prefs.extremeharm == "No")
+					return
+
 				now_pushing = 0
 				user.forceMove(target.loc)
 				user.sizediffStamLoss(target)


### PR DESCRIPTION
## About The Pull Request
Adds a new preference setting for macro stomping. Without the preference set, stomp actions now take three seconds to perform. Harm interactions will always respect the 'extreme content harm' preference.

## Why It's Good For The Game
Prevents a form of 'extreme content harm' from being used against non-consenting users. Users have expressed consistent annoyance at being forced to engage in non-consensual stomping interactions.

## A Port?
No.

## Changelog
:cl:
add: Added a preference for macro stomping
balance: Non-consensual stomping now takes three seconds
balance: Lethal stomping now requires extreme content harm preference
/:cl: