### PR TITLE
Port estrous quirks from SPLURT

### DIFF
--- a/code/__SANDCODE/DEFINES/traits.dm
+++ b/code/__SANDCODE/DEFINES/traits.dm
@@ -8,3 +8,6 @@
 #define TRAIT_INFERTILE			"infertile"
 /// DNC trait, used to prevent cloning
 #define TRAIT_DNC_ORDER			"dnc_order"
+/// Estrous traits, used for mammalian seasonal arousal systems
+#define TRAIT_ESTROUS_ACTIVE	"estrous_active"
+#define TRAIT_ESTROUS_DETECT	"estrous_detect"

--- a/modular_sand/code/datums/traits/neutral.dm
+++ b/modular_sand/code/datums/traits/neutral.dm
@@ -21,3 +21,41 @@
 	gain_text = span_notice("Your womb starts feeling dry and empty, all the life in it begins to fade away...")
 	lose_text = span_love("You feel the warm blow of life flooding your womb, full of newfound, vibrant fertility!")
 	medical_record_text = "Patient doesn't seem able to ovulate properly..."
+
+/datum/quirk/estrous_detection
+	name = "Estrous Detection"
+	desc = "You have a mammalian sense of detecting if someone\'s body longs for breeding."
+	value = 0
+	mob_trait = TRAIT_ESTROUS_DETECT
+	gain_text = span_love("Your senses adjust, allowing a mammalian sense of others' fertility.")
+	lose_text = span_notice("Your sense of others' fertility fades.")
+
+/datum/quirk/estrous_active
+	name = "In Estrous"
+	desc = "Your system burns with the desire to be bred. Satisfying your lust will make you happy, while ignoring it may cause you to become sad and needy."
+	value = 0
+	mob_trait = TRAIT_ESTROUS_ACTIVE
+	gain_text = span_love("You body burns with the desire to be bred.")
+	lose_text = span_notice("You feel more in control of your body and thoughts.")
+
+/datum/quirk/estrous_active/add()
+	// Add examine hook
+	RegisterSignal(quirk_holder, COMSIG_PARENT_EXAMINE, .proc/quirk_examine_estrous_active)
+
+/datum/quirk/estrous_active/remove()
+	// Remove examine hook
+	UnregisterSignal(quirk_holder, COMSIG_PARENT_EXAMINE)
+
+/datum/quirk/estrous_active/proc/quirk_examine_estrous_active(atom/examine_target, mob/living/carbon/human/examiner, list/examine_list)
+	SIGNAL_HANDLER
+
+	// Check if human examiner exists
+	if(!istype(examiner))
+		return
+
+	// Check if examiner lacks the trait, or is self examining
+	if(!HAS_TRAIT(examiner, TRAIT_ESTROUS_DETECT) || (examiner == quirk_holder))
+		return
+
+	// Add quirk message
+	examine_list += span_love("[quirk_holder.p_they(TRUE)] [quirk_holder.p_are()] currently influenced by the estrous cycle, and long for breeding.")

--- a/modular_sand/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/modular_sand/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -12,13 +12,15 @@
 	C.add_quirk(/datum/quirk/estrous_detection, SPECIES_TRAIT)
 
 	// Define round ID
-	var/round_id = text2num(GLOB.round_id)
+	// Requires a server database to use this
+	var/round_id = text2num(GLOB.round_id) || null
 
 	// Define round mating season value
 	var/round_season = ((round_id + (ESTROUS_CYCLE_OFFSET + 2)) % ESTROUS_CYCLE_LENGTH)
 
 	// Check for mating season
-	if(round_season <= 2 && round_season >= 0)
+	// Default to active without variable
+	if((!round_id) || round_season <= 2 && round_season >= 0)
 		// Alert user in chat
 		to_chat(C, span_userlove("It\'s that time again. Your loins lay restless as they await a potential mate."))
 

--- a/modular_sand/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/modular_sand/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -1,3 +1,29 @@
+#define ESTROUS_CYCLE_LENGTH 32
+#define ESTROUS_CYCLE_OFFSET 11
+
 /datum/species/lizard/New()
 	mutant_bodyparts += list("ears" = "None")
 	. = ..()
+
+/datum/species/lizard/ashwalker/on_species_gain(mob/living/carbon/human/C, datum/species/old_species)
+	. = ..()
+
+	// Add estrous detect quirk
+	C.add_quirk(/datum/quirk/estrous_detection, SPECIES_TRAIT)
+
+	// Define round ID
+	var/round_id = text2num(GLOB.round_id)
+
+	// Define round mating season value
+	var/round_season = ((round_id + (ESTROUS_CYCLE_OFFSET + 2)) % ESTROUS_CYCLE_LENGTH)
+
+	// Check for mating season
+	if(round_season <= 2 && round_season >= 0)
+		// Alert user in chat
+		to_chat(C, span_userlove("It\'s that time again. Your loins lay restless as they await a potential mate."))
+
+		// Add estrous quirk
+		C.add_quirk(/datum/quirk/estrous_active, SPECIES_TRAIT)
+
+#undef ESTROUS_CYCLE_LENGTH
+#undef ESTROUS_CYCLE_OFFSET


### PR DESCRIPTION
## About The Pull Request
This PR ports quirks related to the animal breeding cycle from the downstream server SPLURT. The quirks add examine flavor text, and the ability to see said flavor text. No gameplay effects currently exist.

## Why It's Good For The Game
Actions were requested by user SandPoot.

## A Port?
Yes, ported from [SPLURT Station 13](https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13). Originally added to the game in PR https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/pull/20 by GitHub [user NullFag](https://github.com/NullFag).

## Changelog
:cl:
add: Added quirk Estrous Detection
add: Added quirk In Estrous
tweak: Ashwalkers now spawn with the Estrous Detection quirk
tweak: Ashwalkers will now gain the In Estrous quirk during some rounds
/:cl: