### PR TITLE
TETRIS machine rewards refactor

### DIFF
--- a/config/sandstorm/balance.txt
+++ b/config/sandstorm/balance.txt
@@ -57,3 +57,36 @@ BLUESPACEMINER_MULT_OUTPUT 1
 
 ## What is the minimum stock part tier to produce bluespace crystals?
 BLUESPACEMINER_CRYSTAL_TIER 5
+
+###
+## TETRIS
+###
+
+## The machine produces science points based on score
+## Uncomment this to prevent it from doing so
+#TETRIS_NO_SCIENCE
+
+## How many prizes can the machine dispense
+## This is also limited by TETRIS_SCORE_MAX
+TETRIS_PRIZES_MAX 5
+
+## How many points required per prize vended
+## Amount is equal to SCORE divided by TETRIS_REWARD_DIVISOR
+TETRIS_REWARD_DIVISOR 1000
+
+## Minimum score required to message admins
+## This is intended for detecting suspicious scores
+TETRIS_SCORE_HIGH 10000
+
+## Maximum score that can be displayed
+## Score values past this number are ignored
+TETRIS_SCORE_MAX 100000
+
+## Maximum research points that can be generated
+## Score values past this number are ignored
+TETRIS_SCORE_MAX_SCI 10000
+
+## Minimum time between giving rewards
+## This applies to both prizes and research points
+## Time is measured in ticks
+TETRIS_TIME_COOLDOWN 600

--- a/modular_sand/code/controllers/configuration/entries/sandstorm_balance.dm
+++ b/modular_sand/code/controllers/configuration/entries/sandstorm_balance.dm
@@ -64,3 +64,31 @@
 // BSM minimum tier for bluespace crystals
 /datum/config_entry/number/bluespaceminer_crystal_tier
 	config_entry_value = 5
+
+/// TETRIS ARCADE MACHINE ///
+// If the machine should skip producing science points
+/datum/config_entry/flag/tetris_no_science
+
+// Points required per prize vended
+/datum/config_entry/number/tetris_reward_divisor
+	config_entry_value = 1000
+
+// Points required per prize vended
+/datum/config_entry/number/tetris_prizes_max
+	config_entry_value = 5
+
+// Minimum score required to message admins
+/datum/config_entry/number/tetris_score_high
+	config_entry_value = 10000
+
+// Maximum research points that can be generated
+/datum/config_entry/number/tetris_score_max
+	config_entry_value = 100000
+
+// Maximum research points that can be generated
+/datum/config_entry/number/tetris_score_max_sci
+	config_entry_value = 10000
+
+// Minimum time between giving rewards
+/datum/config_entry/number/tetris_time_cooldown
+	config_entry_value = 600

--- a/modular_sand/code/game/machinery/computer/arcade/tetris.dm
+++ b/modular_sand/code/game/machinery/computer/arcade/tetris.dm
@@ -1,5 +1,17 @@
-#define REWARD_DIVISOR 1000
-// At the end of the game, the thing yields tetris_score/REWARD_DIVISOR prize tickets. Adjust accordingly.
+// The machine awards prizes based on score divided by this value
+#define TETRIS_REWARD_DIVISOR 1000
+
+// Score required to message admins
+#define TETRIS_SCORE_HIGH 10000
+
+// Maximum score accepted
+#define TETRIS_SCORE_MAX 100000
+
+// Maximum score to be used for research
+#define TETRIS_SCORE_MAX_SCI 10000
+
+// Time between dispensing prizes
+#define TETRIS_TIME_COOLDOWN 600 // One minute
 
 /obj/machinery/computer/arcade/tetris
 	name = "T.E.T.R.I.S."
@@ -8,6 +20,7 @@
 	icon_state = "arcade"
 	circuit = /obj/item/circuitboard/computer/arcade/tetris
 	light_color = LIGHT_COLOR_GREEN
+	var/cooldown_timer = 0
 
 /obj/machinery/computer/arcade/tetris/Topic(href, href_list)
 	if(..())
@@ -15,24 +28,61 @@
 	else
 		usr.set_machine(src)
 		if(href_list["tetrisScore"])
-			var/temp_score = text2num(href_list["tetrisScore"])
-			var/reward = round(temp_score/REWARD_DIVISOR)
-			prizevend(usr, reward)
+			// Sanitize score as an integer
+			// Restricts maximum score to (default) 100,000
+			var/temp_score = sanitize_num_clamp(text2num(href_list["tetrisScore"]), max=TETRIS_SCORE_MAX)
 
-			// Check if user is a scientist
-			if(usr.mind && (usr.mind.assigned_role == "Scientist" || usr.mind.assigned_role == "Research Director"))
+			// Check for high score
+			if(temp_score > TETRIS_SCORE_HIGH)
+				// Alert admins
+				message_admins("[ADMIN_LOOKUPFLW(usr)] [ADMIN_KICK(usr)] has achieved a score of [temp_score] on [src] in [get_area(src.loc)]! Score exceeds configured suspicion threshold.")
+
+			// Round and clamp prize count from 0 to 5
+			var/reward_count = clamp(round(temp_score/TETRIS_REWARD_DIVISOR), 0, 5)
+
+			// Define score text
+			var/score_text = (reward_count ? temp_score : "PATHETIC! TRY HARDER")
+
+			// Display normal message
+			say("YOUR SCORE: [score_text]!")
+
+			// Check if any prize would be vended
+			if(!reward_count)
+				// Return without further effects
+				return
+
+			// Check cooldown
+			if(world.time < cooldown_timer)
+				// Play a fake prize vend effect based on prizevend()
+				playsound(src, 'sound/machines/machine_vend.ogg', 50, TRUE, extrarange = -3)
+				visible_message(span_notice("[src] sputters for a moment before going quiet."))
+
+				// Return with no further effects
+				return
+
+			// Set cooldown time
+			cooldown_timer = world.time + TETRIS_TIME_COOLDOWN
+
+			// Vend prizes
+			prizevend(usr, reward_count)
+
+			// Define user ID card
+			var/obj/item/card/id/user_id = usr.get_idcard()
+
+			// Check if ID exists
+			// Check if ID has science access
+			if(istype(user_id) && (ACCESS_RESEARCH in user_id.access))
 				// Check if science exists
 				if(SSresearch.science_tech)
+					// Limit maximum research points to (default) 10,000
+					var/score_research_points = clamp(temp_score, 0, TETRIS_SCORE_MAX_SCI)
+
 					// Add science points based on score
-					SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = temp_score))
+					SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = score_research_points))
 
 					// Announce points earned
-					say("Success! Applying [temp_score] points to research algorithms...")
+					say("Research personnel detected. Applying gathered data to algorithms...")
 
-			// User is not a scientist
-			else
-				// Display normal message
-				say("YOUR SCORE: [temp_score]!")
 	return
 
 /obj/machinery/computer/arcade/tetris/attack_ai(user as mob)
@@ -110,3 +160,10 @@
 	user << browse(dat, "window=tetris;size=435x550")
 	user.set_machine(src)
 	onclose(user, "tetris")
+
+// Remove defines
+#undef TETRIS_REWARD_DIVISOR
+#undef TETRIS_SCORE_HIGH
+#undef TETRIS_SCORE_MAX
+#undef TETRIS_SCORE_MAX_SCI
+#undef TETRIS_TIME_COOLDOWN

--- a/modular_sand/code/game/machinery/computer/arcade/tetris.dm
+++ b/modular_sand/code/game/machinery/computer/arcade/tetris.dm
@@ -7,6 +7,9 @@
 #define TETRIS_TIME_COOLDOWN CONFIG_GET(number/tetris_time_cooldown)
 #define TETRIS_NO_SCIENCE CONFIG_GET(flag/tetris_no_science)
 
+// Cooldown defines
+#define TETRIS_COOLDOWN_MAIN cooldown_timer
+
 /obj/machinery/computer/arcade/tetris
 	name = "T.E.T.R.I.S."
 	desc = "The pinnacle of human technology."
@@ -14,7 +17,7 @@
 	icon_state = "arcade"
 	circuit = /obj/item/circuitboard/computer/arcade/tetris
 	light_color = LIGHT_COLOR_GREEN
-	var/cooldown_timer = 0
+	COOLDOWN_DECLARE(TETRIS_COOLDOWN_MAIN)
 
 /obj/machinery/computer/arcade/tetris/Topic(href, href_list)
 	if(..())
@@ -46,7 +49,7 @@
 				return
 
 			// Check cooldown
-			if(world.time < cooldown_timer)
+			if(!COOLDOWN_FINISHED(src, TETRIS_COOLDOWN_MAIN))
 				// Play a fake prize vend effect based on prizevend()
 				playsound(src, 'sound/machines/machine_vend.ogg', 50, TRUE, extrarange = -3)
 				visible_message(span_notice("[src] sputters for a moment before going quiet."))
@@ -55,7 +58,7 @@
 				return
 
 			// Set cooldown time
-			cooldown_timer = world.time + TETRIS_TIME_COOLDOWN
+			COOLDOWN_START(src, TETRIS_COOLDOWN_MAIN, TETRIS_TIME_COOLDOWN)
 
 			// Vend prizes
 			prizevend(usr, reward_count)
@@ -165,3 +168,4 @@
 #undef TETRIS_SCORE_MAX_SCI
 #undef TETRIS_TIME_COOLDOWN
 #undef TETRIS_NO_SCIENCE
+#undef TETRIS_COOLDOWN_MAIN

--- a/modular_sand/code/game/machinery/computer/arcade/tetris.dm
+++ b/modular_sand/code/game/machinery/computer/arcade/tetris.dm
@@ -13,10 +13,7 @@
 /obj/machinery/computer/arcade/tetris
 	name = "T.E.T.R.I.S."
 	desc = "The pinnacle of human technology."
-	icon = 'icons/obj/computer.dmi'
-	icon_state = "arcade"
 	circuit = /obj/item/circuitboard/computer/arcade/tetris
-	light_color = LIGHT_COLOR_GREEN
 	COOLDOWN_DECLARE(TETRIS_COOLDOWN_MAIN)
 
 /obj/machinery/computer/arcade/tetris/Topic(href, href_list)

--- a/modular_sand/code/game/machinery/computer/arcade/tetris.dm
+++ b/modular_sand/code/game/machinery/computer/arcade/tetris.dm
@@ -16,9 +16,23 @@
 		usr.set_machine(src)
 		if(href_list["tetrisScore"])
 			var/temp_score = text2num(href_list["tetrisScore"])
-			say("YOUR SCORE: [temp_score]!")
 			var/reward = round(temp_score/REWARD_DIVISOR)
 			prizevend(usr, reward)
+
+			// Check if user is a scientist
+			if(usr.mind && (usr.mind.assigned_role == "Scientist" || usr.mind.assigned_role == "Research Director"))
+				// Check if science exists
+				if(SSresearch.science_tech)
+					// Add science points based on score
+					SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = temp_score))
+
+					// Announce points earned
+					say("Success! Applying [temp_score] points to research algorithms...")
+
+			// User is not a scientist
+			else
+				// Display normal message
+				say("YOUR SCORE: [temp_score]!")
 	return
 
 /obj/machinery/computer/arcade/tetris/attack_ai(user as mob)


### PR DESCRIPTION
## About The Pull Request
This PR updates the T.E.T.R.I.S. arcade machine with the following attributes
- Adds configuration values to the Sandstorm balance config
- - Allow generating science points
- - Reward divisor
- - Maximum prizes
- - Maximum score
- - Maximum research points
- - Threshold to alert admins
- - Cooldown time between vending
- Adds new messages for vending no prizes
- Adds a cooldown between dispensing rewards
- Adds an admin alert when exceeding the score threshold
- Grants science points if the player's ID has science access
- Limits maximum score
- Limits maximum prizes

## Why It's Good For The Game
This will do the following:
- Add additional configuration
- Add a new method for scientists to earn research points
- Reduce cheating potential

## A Port?
No.

## Changelog
:cl:
balance: T.E.T.R.I.S. arcade machine now generates research points if used by scientists
balance: T.E.T.R.I.S. machine maximum score, prize count, and points payout are now limited
balance: T.E.T.R.I.S. machine can only dispense rewards once per configured time threshold
server: Added configuration settings for the T.E.T.R.I.S. arcade machine
/:cl: