### PR TITLE
357 Speed Loader research fix

### DIFF
--- a/modular_sand/code/modules/uplink/uplink_items.dm
+++ b/modular_sand/code/modules/uplink/uplink_items.dm
@@ -11,3 +11,7 @@
 	desc = "An additional arm harvested from slaves captured by the Syndicate. Comes with an implanter."
 	item = /obj/item/extra_arm
 	cost = 8
+
+// Made craftable, and no longer illegal
+/datum/uplink_item/ammo/revolver
+	illegal_tech = FALSE


### PR DESCRIPTION
## About The Pull Request
Marks the 357 speed loader as non-illegal-tech to prevent an exploit with the research techweb. As it was made craftable in a modular edit, the item can now be made by any normal crew member and used to immediately unlock the Illegal Technology techweb node.

## Why It's Good For The Game
Fixes an exploit that allowed sequence breaking a techweb node.

## A Port?
No.

## Changelog
:cl:
fix: Fixed techweb exploit with 357 speed loader
/:cl: