### PR TITLE
Use english list for In Estrous examine text

### DIFF
--- a/modular_sand/code/datums/traits/neutral.dm
+++ b/modular_sand/code/datums/traits/neutral.dm
@@ -62,30 +62,23 @@
 	update_heat_type()
 
 /datum/quirk/estrous_active/proc/update_heat_type()
-	// Check for male reproductive organs
-	var/breed_male = quirk_holder.has_balls()
+	// Define temporary list of heat phrases
+	var/list/heat_phrases = list()
 
-	// Define possible womb
-	var/obj/item/organ/genital/womb/organ_womb = quirk_holder.getorganslot(ORGAN_SLOT_WOMB)
+	// Check for male hormonal organ
+	if(quirk_holder.has_balls())
+		heat_phrases += list("in rut")
 
-	// Check for female reproductive organs
-	var/breed_female = (quirk_holder.has_vagina() && istype(organ_womb))
+	// Check for female hormonal organ
+	if(quirk_holder.getorganslot(ORGAN_SLOT_WOMB))
+		heat_phrases += list("in estrous")
 
-	// Set variable for both reproductive types
-	if(breed_male && breed_female)
-		heat_type = "in both estrous and rut"
+	// Check for synthetic
+	if(isrobotic(quirk_holder))
+		heat_phrases += list("simulating a hormonal response")
 
-	// Set variable for male-only
-	else if(breed_male)
-		heat_type = "in rut"
-
-	// Set variable for female-only
-	else if(breed_female)
-		heat_type = "in estrous"
-
-	// Set variable for none
-	else
-		positional_orientation = "engage in breeding"
+	// Build English list
+	heat_type = english_list(heat_phrases, nothing_text = "experiencing high hormonal levels")
 
 /datum/quirk/estrous_active/proc/quirk_examine_estrous_active(atom/examine_target, mob/living/carbon/human/examiner, list/examine_list)
 	SIGNAL_HANDLER
@@ -99,4 +92,4 @@
 		return
 
 	// Add quirk message
-	examine_list += span_love("[quirk_holder.p_they(TRUE)] [quirk_holder.p_are()] currently [heat_type], and longs to [positional_orientation].")
+	examine_list += span_love("[quirk_holder.p_they(TRUE)] [quirk_holder.p_are()] currently [heat_type], with a longing to [positional_orientation].")

--- a/modular_sand/code/datums/traits/neutral.dm
+++ b/modular_sand/code/datums/traits/neutral.dm
@@ -67,15 +67,15 @@
 
 	// Check for male hormonal organ
 	if(quirk_holder.has_balls())
-		heat_phrases += list("in rut")
+		heat_phrases += "in rut"
 
 	// Check for female hormonal organ
 	if(quirk_holder.getorganslot(ORGAN_SLOT_WOMB))
-		heat_phrases += list("in estrous")
+		heat_phrases += "in estrous"
 
 	// Check for synthetic
 	if(isrobotic(quirk_holder))
-		heat_phrases += list("simulating a hormonal response")
+		heat_phrases += "simulating hormones"
 
 	// Build English list
 	heat_type = english_list(heat_phrases, nothing_text = "experiencing high hormonal levels")


### PR DESCRIPTION
## About The Pull Request
This commit does the following for In Estrous examine text:
- Adds English list support
- Adds support for synthetic species
- Removes check for Vagina organ
- Updates text to prevent double "and"

## Why It's Good For The Game
This will accomplish the following:
- Create cleaner and more expandable code
- Prevent checking an organ that doesn't produce hormones
- Add more flavor text for synthetic species

## A Port?
No.

## Changelog
:cl:
add: Added Synthetic species flavor text for In Estrous
tweak: In Estrous no longer requires both female organs
code: In Estrous examine text uses English lists
/:cl: