### PR TITLE
Make Gear Harness non-covering

### DIFF
--- a/modular_sand/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_sand/code/modules/clothing/under/miscellaneous.dm
@@ -1,0 +1,8 @@
+/obj/item/clothing/under/misc/gear_harness
+	can_adjust = FALSE
+	body_parts_covered = NONE
+
+/obj/item/clothing/under/misc/gear_harness/toggle_jumpsuit_adjust()
+	// Alert user and return
+	to_chat(usr, span_notice("[src] cannot be adjusted!"))
+	return FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4102,6 +4102,7 @@
 #include "modular_sand\code\modules\clothing\suits\miscellaneous.dm"
 #include "modular_sand\code\modules\clothing\under\_under.dm"
 #include "modular_sand\code\modules\clothing\under\costumes.dm"
+#include "modular_sand\code\modules\clothing\under\miscellaneous.dm"
 #include "modular_sand\code\modules\clothing\under\uniform.dm"
 #include "modular_sand\code\modules\clothing\underwear\_underwear.dm"
 #include "modular_sand\code\modules\clothing\underwear\boxers.dm"


### PR DESCRIPTION
## About The Pull Request
Sets the gear harness to non-covering by default, and removes the ability to adjust it. The toggle function has been updated to prevent false feedback. Users can still use the visibility settings to conceal associated body regions.

## Why It's Good For The Game
This item is designed to facilitate playing as a naked character while being able to handle items, but acts as normal clothing by default. In addition, it is an invisible item that does not appear on the mob, and has no way of covering them.

## A Port?
No.

## Changelog
:cl:
tweak: The Gear Harness is now non-covering
/:cl: