### PR TITLE
Fix cargo production access

### DIFF
--- a/modular_sand/code/modules/research/machinery/departmental_protolathe.dm
+++ b/modular_sand/code/modules/research/machinery/departmental_protolathe.dm
@@ -8,7 +8,7 @@
 	req_access = list(ACCESS_MEDICAL)
 
 /obj/machinery/rnd/production/protolathe/department/cargo
-	req_access = list(ACCESS_MAILSORTING)
+	req_one_access = list(ACCESS_CARGO, ACCESS_MINING)
 
 /obj/machinery/rnd/production/protolathe/department/science
 	req_access = list(ACCESS_RESEARCH)

--- a/modular_sand/code/modules/research/machinery/departmental_protolathe.dm
+++ b/modular_sand/code/modules/research/machinery/departmental_protolathe.dm
@@ -8,7 +8,7 @@
 	req_access = list(ACCESS_MEDICAL)
 
 /obj/machinery/rnd/production/protolathe/department/cargo
-	req_access = list(ACCESS_CARGO)
+	req_access = list(ACCESS_MAILSORTING)
 
 /obj/machinery/rnd/production/protolathe/department/science
 	req_access = list(ACCESS_RESEARCH)

--- a/modular_sand/code/modules/research/machinery/departmental_techfab.dm
+++ b/modular_sand/code/modules/research/machinery/departmental_techfab.dm
@@ -8,7 +8,7 @@
 	req_access = list(ACCESS_MEDICAL)
 
 /obj/machinery/rnd/production/techfab/department/cargo
-	req_access = list(ACCESS_MAILSORTING)
+	req_one_access = list(ACCESS_CARGO, ACCESS_MINING)
 
 /obj/machinery/rnd/production/techfab/department/science
 	req_access = list(ACCESS_RESEARCH)

--- a/modular_sand/code/modules/research/machinery/departmental_techfab.dm
+++ b/modular_sand/code/modules/research/machinery/departmental_techfab.dm
@@ -8,7 +8,7 @@
 	req_access = list(ACCESS_MEDICAL)
 
 /obj/machinery/rnd/production/techfab/department/cargo
-	req_access = list(ACCESS_CARGO)
+	req_access = list(ACCESS_MAILSORTING)
 
 /obj/machinery/rnd/production/techfab/department/science
 	req_access = list(ACCESS_RESEARCH)


### PR DESCRIPTION
## About The Pull Request
Changes the production machinery access requirement for cargo from `ACCESS_CARGO` to `ACCESS_MAILSORTING` to fix an issue that prevented Shaft Miners from using the machine.

## Why It's Good For The Game
Allows Shaft Miners to use the Cargo protolathe.

## A Port?
No.

## Changelog
:cl:
fix: Fixed Cargo protolathe access (MAILSORTING instead of CARGO)
/:cl: