### PR TITLE
Allow material access from protolathes

### DIFF
--- a/code/__SANDCODE/DEFINES/access.dm
+++ b/code/__SANDCODE/DEFINES/access.dm
@@ -1,0 +1,6 @@
+// Returns used by production machinery
+// Based on access type that passed the check
+#define PROTOLOCK_ACCESS_NORMAL 1
+#define PROTOLOCK_ACCESS_LOWPOP 2
+#define PROTOLOCK_ACCESS_CAPTAIN 3
+#define PROTOLOCK_ACCESS_MINERAL 4

--- a/modular_sand/code/modules/mob/mob.dm
+++ b/modular_sand/code/modules/mob/mob.dm
@@ -61,9 +61,23 @@
 		// Allow use
 		return TRUE
 
-	// User does not have access
+	// User does not have normal access
+	// Check for ORM access
+	if(ACCESS_MINERAL_STOREROOM in user_id.access)
+		// Check if already on material screen
+		if(machine_target.screen != RESEARCH_FABRICATOR_SCREEN_MATERIALS)
+			// Warn in local chat
+			machine_target.say("Access limited: Configuring for ORM remote control mode.")
+
+			// Set to material screen
+			machine_target.screen = RESEARCH_FABRICATOR_SCREEN_MATERIALS
+
+		// Allow use
+		return TRUE
+
+	// User has no access
 	// Warn in local chat, then return
-	machine_target.say("Access denied: No valid departmental credentials detected.")
+	machine_target.say("Access denied: No valid departmental or mineral credentials detected.")
 	return FALSE
 
 #undef JOB_MINIMAL_ACCESS

--- a/modular_sand/code/modules/research/machinery/_production.dm
+++ b/modular_sand/code/modules/research/machinery/_production.dm
@@ -11,6 +11,8 @@
 
 	// Check if user can use machine
 	if(!user.can_use_production(src))
+		// Warn in local chat and return
+		say("Access denied: No valid departmental or mineral credentials detected.")
 		return
 
 	// Return normally
@@ -22,7 +24,14 @@
 		return ..()
 
 	// Check if user can use machine
-	if(!usr.can_use_production(src))
+	if(!usr.can_use_production_topic(src, raw, ls))
+		// Alert in local chat
+		usr.visible_message(span_warning("[usr] pushes a button on [src], causing it to chime with the familiar sound of rejection."), span_warning("The machine buzzes with a soft chime. It seems you don't have access to that button."))
+
+		// Play sound
+		playsound(loc, 'sound/machines/uplinkerror.ogg', 70, 0)
+
+		// Return
 		return
 
 	// Return normally

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -235,6 +235,7 @@
 #include "code\__HELPERS\sorts\InsertSort.dm"
 #include "code\__HELPERS\sorts\MergeSort.dm"
 #include "code\__HELPERS\sorts\TimSort.dm"
+#include "code\__SANDCODE\DEFINES\access.dm"
 #include "code\__SANDCODE\DEFINES\chat.dm"
 #include "code\__SANDCODE\DEFINES\DNA.dm"
 #include "code\__SANDCODE\DEFINES\keybindings.dm"


### PR DESCRIPTION
## About The Pull Request
This PR allows crew with `ACCESS_MINERAL_STOREROOM` access to use production machinery in 'mineral only' mode when normal access isn't found. This allows changing screens, synchronizing, and ejecting materials.

In addition:
- Adds new return types for access types
- Adds a separate function for topic access checks
- Adds new feedback for topic access denial
- Changes the main access check to use `allowed` proc
- Moves feedback messages to the production machine

## Why It's Good For The Game
Allows for engineers and other crew with material access to continue accessing resources from any production machinery on the station.

## A Port?
No.

## Changelog
:cl:
add: Added better feedback for production machinery topic access denial
tweak: Production machinery access checks now work for all mobs
balance: Production machinery can now be used in 'mineral mode' by crew with ORM access
/:cl: