### PR TITLE
Add robotics production restrictions

### DIFF
--- a/modular_sand/code/modules/mob/mob.dm
+++ b/modular_sand/code/modules/mob/mob.dm
@@ -28,7 +28,11 @@
 /mob/proc/set_thirst(change)
 	thirst = max(0, change)
 
-/mob/proc/can_use_production(obj/machinery/rnd/production/machine_target)
+/mob/proc/can_use_production(obj/machinery/machine_target)
+	// Check if access is required
+	if(!machine_target.req_access)
+		return TRUE
+
 	// Check if server is NOT using minimal access
 	// This is intended for low populations
 	if((!PROTOLOCK_DURING_LOWPOP) && (!JOB_MINIMAL_ACCESS))
@@ -87,6 +91,43 @@
 		if(PROTOLOCK_ACCESS_MINERAL)
 			// Check if permitted topic
 			if(ls["ejectsheet"])
+				return TRUE
+
+			// Topic prohibited
+			// Deny usage
+			else
+				return FALSE
+
+	// Default to false
+	return FALSE
+
+/mob/proc/can_use_mechfab_topic(obj/machinery/mecha_part_fabricator/machine_target, action, var/list/params)
+	// Basic actions that are always permitted
+	if(action == "sync_rnd")
+		return TRUE
+
+	// Define user's access type
+	var/user_access = usr.can_use_production(machine_target)
+
+	// Switch result based on access type
+	// This currently doesn't do anything special
+	switch(user_access)
+		// Type: Low population
+		if(PROTOLOCK_ACCESS_LOWPOP)
+			return TRUE
+
+		// Type: Standard
+		if(PROTOLOCK_ACCESS_NORMAL)
+			return TRUE
+
+		// Type: Captain
+		if(PROTOLOCK_ACCESS_CAPTAIN)
+			return TRUE
+
+		// Type: Mineral / ORM
+		if(PROTOLOCK_ACCESS_MINERAL)
+			// Check if permitted topic
+			if(action == "remove_mat")
 				return TRUE
 
 			// Topic prohibited

--- a/modular_sand/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/modular_sand/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -1,3 +1,9 @@
+/obj/machinery/mecha_part_fabricator/maint
+	req_access = null
+
+/obj/machinery/mecha_part_fabricator/offstation
+	req_access = null
+
 /obj/machinery/mecha_part_fabricator/ui_interact(mob/user, datum/tgui/ui)
 	// Check if user can use machine
 	if(!user.can_use_production(src))

--- a/modular_sand/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/modular_sand/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -1,22 +1,28 @@
-/obj/machinery/rnd/production/Initialize(mapload)
-	. = ..()
-
-	// Generate access lists
-	gen_access()
-
-/obj/machinery/rnd/production/ui_interact(mob/user)
+/obj/machinery/mecha_part_fabricator/ui_interact(mob/user, datum/tgui/ui)
 	// Check if user can use machine
 	if(!user.can_use_production(src))
-		// Warn in local chat and return
-		say("Access denied: No valid departmental or mineral credentials detected.")
+		// Check if UI doesn't exist
+		if(!ui)
+			// Send normal warning
+			say("Access denied: No valid credentials detected.")
+
+		// UI does exist
+		else
+			// Close UI
+			ui.close()
+
+			// Send alternate warning
+			say("Access revoked: Valid credentials no longer detected.")
+
+		// Return
 		return
 
 	// Return normally
 	. = ..()
 
-/obj/machinery/rnd/production/Topic(raw, ls)
+/obj/machinery/mecha_part_fabricator/ui_act(action, var/list/params)
 	// Check if user can use machine
-	if(!usr.can_use_production_topic(src, raw, ls))
+	if(!usr.can_use_mechfab_topic(src, action, params))
 		// Alert in local chat
 		usr.visible_message(span_warning("[usr] pushes a button on [src], causing it to chime with the familiar sound of rejection."), span_warning("The machine buzzes with a soft chime. It seems you don't have access to that button."))
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4258,6 +4258,7 @@
 #include "modular_sand\code\modules\tgs\custom_procs.dm"
 #include "modular_sand\code\modules\uplink\uplink_items.dm"
 #include "modular_sand\code\modules\uplink\uplink_roles.dm"
+#include "modular_sand\code\modules\vehicles\mecha\mech_fabricator.dm"
 #include "modular_sand\code\modules\vending\autodrobe.dm"
 #include "modular_sand\code\modules\vending\clothesmate.dm"
 #include "modular_sand\code\modules\vending\kinkmate.dm"


### PR DESCRIPTION
## About The Pull Request
This commit updates the production machinery restrictions to include mech fabricators. Old production check code has been updated for use with generic machines, and some checks have been moved. Alternative `maint` and `offstation` variants have had their access requirements removed to compensate.

Acts as a follow-up to: https://github.com/Sandstorm-Station/Sandstorm-Station-13/pull/303

## Why It's Good For The Game
As with the original PR, this will also reduce cases of unauthorized ("grey tiding") production use for **standard** mech fabricators.

## A Port?
No.

## Changelog
:cl:
balance: Mech fabricators now use their access restrictions
balance: Removed access requirements for maintenance and off-station mech fabricators
/:cl: