### PR TITLE
Allows for seeing lust levels inside the Interaction menu

### DIFF
--- a/modular_sand/code/datums/components/interaction_menu_granter.dm
+++ b/modular_sand/code/datums/components/interaction_menu_granter.dm
@@ -86,8 +86,16 @@
 	.["isTargetSelf"] = target == self
 	.["interactingWith"] = target != self ? "Interacting with \the [target]..." : "Interacting with yourself..."
 	.["selfAttributes"] = self.list_interaction_attributes(self)
+	.["lust"] = self.get_lust()
+	.["maxLust"] = self.get_lust_tolerance() * 3
 	if(target != self)
 		.["theirAttributes"] = target.list_interaction_attributes(self)
+		if(HAS_TRAIT(user, TRAIT_ESTROUS_DETECT))
+			.["theirLust"] = target.get_lust()
+			.["theirMaxLust"] = target.get_lust_tolerance() * 3
+		else
+			.["theirLust"] = null
+			.["theirMaxLust"] = null
 
 	//Getting interactions
 	var/list/sent_interactions = list()

--- a/tgui/packages/tgui/interfaces/MobInteraction.tsx
+++ b/tgui/packages/tgui/interfaces/MobInteraction.tsx
@@ -2,15 +2,19 @@ import { filter, map, sortBy } from 'common/collections';
 import { flow } from 'common/fp';
 import { createSearch } from 'common/string';
 import { useBackend, useLocalState } from '../backend';
-import { BlockQuote, Button, Flex, LabeledList, Icon, Input, Section, Table, Tabs, Stack } from '../components';
+import { BlockQuote, Button, Flex, Icon, Input, LabeledList, ProgressBar, Section, Table, Tabs, Stack } from '../components';
 import { TableCell, TableRow } from '../components/Table';
 import { Window } from '../layouts';
 
 type HeaderInfo = {
   isTargetSelf: boolean;
   interactingWith: string;
+  lust: number;
+  maxLust: number;
   selfAttributes: string[];
   theirAttributes: string[];
+  theirLust: number;
+  theirMaxLust: number;
 }
 
 type ContentInfo = {
@@ -73,8 +77,12 @@ export const MobInteraction = (props, context) => {
   const {
     isTargetSelf,
     interactingWith,
+    lust,
+    maxLust,
     selfAttributes,
     theirAttributes,
+    theirLust,
+    theirMaxLust,
   } = data;
   const [tabIndex, setTabIndex] = useLocalState(context, 'tabIndex', 0);
 
@@ -86,28 +94,40 @@ export const MobInteraction = (props, context) => {
       <Window.Content overflow="auto">
         <Section title={interactingWith}>
           <Table>
-            <Table.Cell>
-              <BlockQuote>
-                You...<br />
-                {selfAttributes.map(attribute => (
-                  <div key={attribute}>
-                    {attribute}<br />
-                  </div>
-                ))}
-              </BlockQuote>
-            </Table.Cell>
-            {!isTargetSelf ? (
+            <Table.Row>
               <Table.Cell>
                 <BlockQuote>
-                  They...<br />
-                  {theirAttributes.map(attribute => (
+                  You...<br />
+                  {selfAttributes.map(attribute => (
                     <div key={attribute}>
                       {attribute}<br />
                     </div>
                   ))}
                 </BlockQuote>
               </Table.Cell>
-            ) : (null)}
+              {!isTargetSelf ? (
+                <Table.Cell>
+                  <BlockQuote>
+                    They...<br />
+                    {theirAttributes.map(attribute => (
+                      <div key={attribute}>
+                        {attribute}<br />
+                      </div>
+                    ))}
+                  </BlockQuote>
+                </Table.Cell>
+              ) : (null)}
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>
+                <ProgressBar value={lust} maxValue={maxLust} color="purple" mt="10px"><Icon name="heart" /></ProgressBar>
+              </Table.Cell>
+              {(!isTargetSelf && !isNaN(theirLust)) ? (
+                <Table.Cell>
+                  <ProgressBar value={theirLust} maxValue={theirMaxLust} color="purple"><Icon name="heart" /></ProgressBar>
+                </Table.Cell>
+              ) : (null)}
+            </Table.Row>
           </Table>
         </Section>
         <Section>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/43283559/224527391-951f503c-473b-41fb-af8f-d54373dd2dda.png)
You require estrous detection to see theirs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Info.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
qol: Lust levels can be seen in the interaction menu (you can only see theirs if you have estrous detection).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
