### PR TITLE
Revert RnD console locks

### DIFF
--- a/modular_sand/code/modules/research/rdconsole.dm
+++ b/modular_sand/code/modules/research/rdconsole.dm
@@ -1,2 +1,0 @@
-/obj/machinery/computer/rdconsole
-	locked = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4213,7 +4213,6 @@
 #include "modular_sand\code\modules\reagents\reagent_containers\dropper.dm"
 #include "modular_sand\code\modules\reagents\reagent_containers\glass.dm"
 #include "modular_sand\code\modules\reagents\reagent_containers\spray.dm"
-#include "modular_sand\code\modules\research\rdconsole.dm"
 #include "modular_sand\code\modules\research\stock_parts.dm"
 #include "modular_sand\code\modules\research\designs\autolathe_designs.dm"
 #include "modular_sand\code\modules\research\designs\biogenerator_designs.dm"


### PR DESCRIPTION
## About The Pull Request
This PR reverts the change causing R&D consoles to be locked by default upon creation, as it had unintended consequences. This restores the exploit of disassembling locked consoles to bypass locks.

## Why It's Good For The Game
Console locks were causing unintended issues, including those reported for ghost roles. The benefit of this change did not outweigh the issues caused.

## A Port?
No.

## Changelog
:cl:
tweak: Reverted R&D consoles locking by default
/:cl: