### PR TITLE
Space Romans

### DIFF
--- a/modular_sand/code/modules/jobs/job_types/_job_alt_titles.dm
+++ b/modular_sand/code/modules/jobs/job_types/_job_alt_titles.dm
@@ -1,6 +1,6 @@
 //Command
 /datum/job/captain
-	alt_titles = list("Colony Overseer")
+	alt_titles = list("Colony Overseer", "Senator", "Consul")
 
 /datum/job/chief_engineer
 	alt_titles = list("Senior Engineer")
@@ -9,7 +9,7 @@
 	alt_titles = list("Crew Resource Officer", "Executive Officer")
 
 /datum/job/hos
-	alt_titles = list("Chief of Security", "Sheriff")
+	alt_titles = list("Chief of Security", "Sheriff", "Praetor")
 
 /datum/job/qm
 	alt_titles = list("Resource Manager", "Logistics Supervisor")
@@ -32,7 +32,7 @@
 	alt_titles = list("Barista")
 
 /datum/job/chaplain
-	alt_titles = list("Priest", "Cult Leader", "Pope", "Bichop")
+	alt_titles = list("Priest", "Cult Leader", "Pope", "Bichop", "Pontiff")
 
 /datum/job/clown //The most useless role in the game, delet this
 	alt_titles = list("Entertainer")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds new, Roman Republic themed alt-titles for the Captain, Head of Security, and the Chaplain. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This pull request ports the Senator alt title for the captain from Splurt, and also adds a "Consul" Alt title. The HoS gets a new title, "Praetor", and the chap gets "Pontiff". Roma Invitca, even in space!
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Given that Splurt has a senator alt-title and has a bunch of meme alt titles in general, what's wrong with a bit of harmless RP? (Yes, I get we are HRP, but still)
## A Port?

Partially
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl: Arrhythmia_V
Code/Add: Alt Titles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
