### PR TITLE
Adds hints to picking up people/certain simple mobs

### DIFF
--- a/code/datums/elements/mob_holder.dm
+++ b/code/datums/elements/mob_holder.dm
@@ -25,6 +25,7 @@
 
 	RegisterSignal(target, COMSIG_CLICK_ALT, .proc/mob_try_pickup)
 	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/on_examine)
+	RegisterSignal(target, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, .proc/on_requesting_context_from_item)
 
 /datum/element/mob_holder/Detach(datum/source, force)
 	. = ..()
@@ -34,6 +35,17 @@
 /datum/element/mob_holder/proc/on_examine(mob/living/source, mob/user, list/examine_list)
 	if(ishuman(user) && !istype(source.loc, /obj/item/clothing/head/mob_holder))
 		examine_list += "<span class='notice'>Looks like [source.p_they(FALSE)] can be picked up with <b>Alt+Click</b>!</span>"
+
+/datum/element/mob_holder/proc/on_requesting_context_from_item(
+	obj/source,
+	list/context,
+	obj/item/held_item,
+	mob/living/user,
+)
+	SIGNAL_HANDLER
+
+	LAZYSET(context[SCREENTIP_CONTEXT_ALT_LMB], INTENT_ANY, "Pick up")
+	return CONTEXTUAL_SCREENTIP_SET
 
 /datum/element/mob_holder/proc/mob_try_pickup(mob/living/source, mob/user)
 	if(!ishuman(user) || !user.Adjacent(source) || user.incapacitated())

--- a/modular_sand/code/datums/elements/holder_micro.dm
+++ b/modular_sand/code/datums/elements/holder_micro.dm
@@ -15,7 +15,7 @@
 	var/obj/item/clothing/head/mob_holder/holder = micro.loc
 	if(istype(holder))
 		var/mob/living/living = get_atom_on_turf(micro.loc, /mob/living)
-		if(living && (abs(get_size(living)/get_size(micro)) < 2.0))
+		if(living && (COMPARE_SIZES(living, micro)) < 2.0)
 			living.visible_message(span_warning("\The [living] drops [micro] as [micro.p_they()] grow\s too big to carry."),
 								span_warning("You drop \The [living] as [living.p_they()] grow\s too big to carry."),
 								target=micro,
@@ -25,8 +25,19 @@
 			holder.release()
 
 /datum/element/mob_holder/micro/on_examine(mob/living/source, mob/user, list/examine_list)
-	if(ishuman(user) && !istype(source.loc, /obj/item/clothing/head/mob_holder) && (abs(get_size(user)/get_size(source)) >= 2.0))
+	if(ishuman(user) && !istype(source.loc, /obj/item/clothing/head/mob_holder) && (COMPARE_SIZES(user, source)) >= 2.0)
 		examine_list += span_notice("Looks like [source.p_they(FALSE)] can be picked up using <b>Alt+Click and grab intent</b>!")
+
+/// Do not inherit from /mob_holder, interactions are different.
+/datum/element/mob_holder/micro/on_requesting_context_from_item(
+	obj/source,
+	list/context,
+	obj/item/held_item,
+	mob/living/user,
+)
+
+	LAZYSET(context[SCREENTIP_CONTEXT_ALT_LMB], INTENT_GRAB, "Pick up")
+	return CONTEXTUAL_SCREENTIP_SET
 
 /datum/element/mob_holder/micro/proc/mob_pickup_micro(mob/living/source, mob/user)
 	var/obj/item/clothing/head/mob_holder/micro/holder = new(get_turf(source), source, worn_state, alt_worn, right_hand, left_hand, inv_slots)
@@ -53,7 +64,7 @@
 		to_chat(user, span_warning("You can't pick yourself up."))
 		source.balloon_alert(user, "cannot pick yourself!")
 		return FALSE
-	if(abs(get_size(user)/get_size(source)) < 2.0 )
+	if(COMPARE_SIZES(user, source) < 2.0)
 		to_chat(user, span_warning("They're too big to pick up!"))
 		source.balloon_alert(user, "too big to pick up!")
 		return FALSE
@@ -68,8 +79,8 @@
 	source.visible_message(span_warning("[user] starts picking up [source]."), \
 					span_userdanger("[user] starts picking you up!"))
 	source.balloon_alert(user, "picking up")
-	var/p = abs(get_size(source)/get_size(user) * 40) //Scale how fast the pickup will be depending on size difference
-	if(!do_after(user, p, target = source))
+	var/time_required = COMPARE_SIZES(source, user) * 40 //Scale how fast the pickup will be depending on size difference
+	if(!do_after(user, time_required, target = source))
 		return FALSE
 
 	if(user.get_active_held_item())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://github.com/Sandstorm-Station/Sandstorm-Station-13/assets/43283559/d6f70091-b785-4b97-a813-24c465bb87a4)
![image](https://github.com/Sandstorm-Station/Sandstorm-Station-13/assets/43283559/82028dda-9f2b-4cc3-847a-6e2bfffb3ab3)
![image](https://github.com/Sandstorm-Station/Sandstorm-Station-13/assets/43283559/71dea563-52a9-40e5-a69e-22d25e631690)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People still have no idea how to pick up people, they probably still won't because majority of those smartasses play with it off, at least i get a reason to laugh at their faces more.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
Obviously not.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
tweak: How to grab small people and certain simple mobs is now explained on the screen hints, if you have them verbose that is.
code: Applied COMPARE_SIZES macro to the micro code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
