### PR TITLE
Makes the pick up verb less shit

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -588,17 +588,14 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	set category = "Object"
 	set name = "Pick up"
 
-	if(usr.incapacitated() || !Adjacent(usr) || usr.lying)
-		return
-
 	if(iscyborg(usr))
 		var/obj/item/gripper/gripper = usr.get_active_held_item(TRUE)
-		if(istype(gripper))
-			gripper.pre_attack(src, usr, get_dist(src, usr))
+		if(istype(gripper) && !gripper.wrapped)
+			usr.ClickOn(src)
 		return
 
 	if(usr.get_active_held_item() == null) // Let me know if this has any problems -Yota
-		usr.UnarmedAttack(src)
+		usr.ClickOn(src)
 
 //This proc is executed when someone clicks the on-screen UI button.
 //The default action is attack_self().


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The pick up verb has different checks for picking up stuff than when you just click the thing. This just makes the verb click for you instead.
So you can now pick up stuff while lying down using the right click menu!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
fix: Made the pick up verb act as a click, removing dumb checks that click normally would not have.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
