### PR TITLE
Prevents buttons from showing on interaction menu if your mob type is blacklisted

### DIFF
--- a/modular_sand/code/datums/components/interaction_menu_granter.dm
+++ b/modular_sand/code/datums/components/interaction_menu_granter.dm
@@ -102,6 +102,7 @@
 	.["maxLust"] = self.get_lust_tolerance() * 3
 
 	.["max_distance"] = 0
+	.["user_is_blacklisted"] = SSinteractions.is_blacklisted(self)
 	var/required_from_user = NONE
 	if(self.has_mouth())
 		required_from_user |= INTERACTION_REQUIRE_MOUTH
@@ -212,6 +213,7 @@
 	.["theirAttributes"] = null
 	.["target_has_active_player"] = null
 	.["max_distance"] = null
+	.["target_is_blacklisted"] = null
 	.["required_from_target"] = null
 	.["required_from_target_exposed"] = null
 	.["required_from_target_unexposed"] = null
@@ -226,6 +228,7 @@
 		// Always TRUE if has key, 2 if cliented, FALSE if nobody owns it
 		.["target_has_active_player"] = target.ckey ? (target.client ? 2 : TRUE) : FALSE
 		.["max_distance"] = get_dist(self, target)
+		.["target_is_blacklisted"] = SSinteractions.is_blacklisted(target)
 		var/required_from_target = NONE
 		if(target.has_mouth())
 			required_from_target |= INTERACTION_REQUIRE_MOUTH

--- a/modular_sand/code/datums/interactions/interaction_datums/interaction_definitions.dm
+++ b/modular_sand/code/datums/interactions/interaction_datums/interaction_definitions.dm
@@ -2,6 +2,7 @@
 	description = "Shake their hand."
 	simple_message = "USER shakes the hand of TARGET."
 	required_from_user = INTERACTION_REQUIRE_HANDS
+	required_from_target = INTERACTION_REQUIRE_HANDS
 
 /datum/interaction/pat
 	description = "Pat their shoulder."
@@ -43,6 +44,7 @@
 	description = "Make a pinky promise with them!"
 	simple_message = "USER hooks their pinky with TARGET's! Pinky Promise!"
 	required_from_user = INTERACTION_REQUIRE_HANDS
+	required_from_target = INTERACTION_REQUIRE_HANDS
 
 /datum/interaction/bird
 	description = "Flip them the bird!"

--- a/tgui/packages/tgui/interfaces/MobInteraction.tsx
+++ b/tgui/packages/tgui/interfaces/MobInteraction.tsx
@@ -20,6 +20,8 @@ type HeaderInfo = {
 
 type ContentInfo = {
   interactions: InteractionData[];
+  user_is_blacklisted: boolean;
+  target_is_blacklisted: boolean;
 }
 
 type InteractionData = {
@@ -207,6 +209,7 @@ const InteractionsTab = (props, context) => {
     searchText,
     data)
     || [];
+  const { user_is_blacklisted, target_is_blacklisted } = data;
   return (
     <Section overflow="auto" position="absolute" right="6px" left="6px" bottom={(364 - innerHeight) + "px"} top="58px">
       <Table>
@@ -244,11 +247,10 @@ const InteractionsTab = (props, context) => {
           ) : (
             <Section align="center">
               {
-                searchText ? (
-                  "No matching results."
-                ) : (
-                  "No interactions available."
-                )
+                user_is_blacklisted || target_is_blacklisted
+                  ? `${user_is_blacklisted ? "Your" : "Their"} mob type is blacklisted from interactions`
+                  : searchText ? "No matching results."
+                    : "No interactions available."
               }
             </Section>
           )
@@ -265,12 +267,15 @@ export const sortInteractions = (interactions, searchText = '', data) => {
   const testSearch = createSearch<InteractionData>(searchText,
     interaction => interaction.desc);
   const {
-    isTargetSelf,
-    verb_consent,
     extreme_pref,
+    isTargetSelf,
     target_has_active_player,
-    theyAllowLewd,
+    target_is_blacklisted,
     theyAllowExtreme,
+    theyAllowLewd,
+    user_is_blacklisted,
+    verb_consent,
+
 
     max_distance,
     required_from_user,
@@ -284,6 +289,10 @@ export const sortInteractions = (interactions, searchText = '', data) => {
     target_num_feet,
   } = data;
   return flow([
+    // Blacklists completely disable any and all interactions
+    filter(interaction =>
+      !user_is_blacklisted && !target_is_blacklisted),
+
     // Optional search term, do before the others so we don't even run the tests
     searchText && filter(testSearch),
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, also adjust some interactions to make more sense.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Helpful.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
qol: Buttons for interactions don't appear on interaction menu if your mob type (or theirs) is blacklist, preventing you from losing time with "Y DOES NOT WORK".
tweak: Changed some interaction requirements to make more sense.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
