### PR TITLE
Fixes interactions that can be done if requirement allows exposed or unexposed

### DIFF
--- a/code/modules/unit_tests/interactions.dm
+++ b/code/modules/unit_tests/interactions.dm
@@ -3,7 +3,8 @@
 	SSinteractions.prepare_interactions()
 	if(!SSinteractions.interactions || !length(SSinteractions.interactions))
 		Fail("make_interactions() was called but SSinteractions.interactions is empty.")
-	for(var/datum/interaction/interaction as anything in SSinteractions.interactions)
+	for(var/interaction_type in SSinteractions.interactions)
+		var/datum/interaction/interaction = SSinteractions.interactions[interaction_type]
 		if(!interaction.description)
 			Fail("Basetype [interaction.type] located within SSinteractions.interactions")
 		if(interaction.required_from_user_exposed && interaction.required_from_user_unexposed)

--- a/code/modules/unit_tests/interactions.dm
+++ b/code/modules/unit_tests/interactions.dm
@@ -3,4 +3,13 @@
 	SSinteractions.prepare_interactions()
 	if(!SSinteractions.interactions || !length(SSinteractions.interactions))
 		Fail("make_interactions() was called but SSinteractions.interactions is empty.")
+	for(var/datum/interaction/interaction as anything in SSinteractions.interactions)
+		if(!interaction.description)
+			Fail("Basetype [interaction.type] located within SSinteractions.interactions")
+		if(interaction.required_from_user_exposed && interaction.required_from_user_unexposed)
+			if(interaction.required_from_user_exposed != interaction.required_from_user_unexposed)
+				Fail("Interaction [interaction.description]([interaction.type]) has non-matching requirements for user exposed and unexposed, this is unsupported!")
+		if(interaction.required_from_target_exposed && interaction.required_from_target_unexposed)
+			if(interaction.required_from_target_exposed != interaction.required_from_target_unexposed)
+				Fail("Interaction [interaction.description]([interaction.type]) has non-matching requirements for target exposed and unexposed, this is unsupported!")
 	return

--- a/modular_sand/code/controllers/subsystem/interactions.dm
+++ b/modular_sand/code/controllers/subsystem/interactions.dm
@@ -40,9 +40,12 @@ SUBSYSTEM_DEF(interactions)
 /datum/controller/subsystem/interactions/proc/prepare_interactions()
 	QDEL_NULL_LIST(interactions)
 	interactions = list()
-	for(var/itype in subtypesof(/datum/interaction))
-		var/datum/interaction/I = new itype()
-		interactions["[itype]"] = I
+	for(var/datum/interaction/interaction as anything in subtypesof(/datum/interaction))
+		// Basetype, do not create
+		if(!initial(interaction.description))
+			continue
+		interaction = new()
+		interactions["[interaction.type]"] = interaction
 
 /// Blacklisting!
 /datum/controller/subsystem/interactions/proc/prepare_blacklisted_mobs()

--- a/modular_sand/code/controllers/subsystem/interactions.dm
+++ b/modular_sand/code/controllers/subsystem/interactions.dm
@@ -44,7 +44,7 @@ SUBSYSTEM_DEF(interactions)
 		// Basetype, do not create
 		if(!initial(interaction.description))
 			continue
-		interaction = new()
+		interaction = new interaction()
 		interactions["[interaction.type]"] = interaction
 
 /// Blacklisting!

--- a/modular_sand/code/datums/components/interaction_menu_granter.dm
+++ b/modular_sand/code/datums/components/interaction_menu_granter.dm
@@ -424,6 +424,9 @@
 	var/list/sent_interactions = list()
 	for(var/interaction_key in SSinteractions.interactions)
 		var/datum/interaction/I = SSinteractions.interactions[interaction_key]
+		// THIS IS A BASETYPE, DO NOT SEND
+		if(!I.description)
+			continue
 		var/list/interaction = list()
 		interaction["key"] = I.type
 		interaction["desc"] = I.description

--- a/modular_sand/code/datums/interactions/_interaction.dm
+++ b/modular_sand/code/datums/interactions/_interaction.dm
@@ -22,7 +22,7 @@
 
 /// The base of all interactions
 /datum/interaction
-	var/description = "Interact with them."
+	var/description
 	var/simple_message
 	var/simple_style = "notice"
 	var/write_log_user

--- a/modular_sand/code/datums/interactions/interaction_datums/lewd/slap.dm
+++ b/modular_sand/code/datums/interactions/interaction_datums/lewd/slap.dm
@@ -1,0 +1,9 @@
+/datum/interaction/lewd/slap
+	description = "Slap their ass."
+	simple_message = "USER slaps TARGET right on the ass!"
+	simple_style = "danger"
+	interaction_sound = 'sound/weapons/slap.ogg'
+	required_from_user = INTERACTION_REQUIRE_HANDS
+
+	write_log_user = "ass-slapped"
+	write_log_target = "was ass-slapped by"

--- a/modular_sand/code/datums/interactions/lewd_interactions.dm
+++ b/modular_sand/code/datums/interactions/lewd_interactions.dm
@@ -1,13 +1,8 @@
 // If I could have gotten away with using a tilde in the type path, I would have.
 /datum/interaction/lewd
-	description = "Slap their ass."
-	simple_message = "USER slaps TARGET right on the ass!"
-	simple_style = "danger"
-	interaction_sound = 'sound/weapons/slap.ogg'
+	description = null
+	simple_style = "lewd"
 	interaction_flags = INTERACTION_FLAG_ADJACENT | INTERACTION_FLAG_OOC_CONSENT
-
-	write_log_user = "ass-slapped"
-	write_log_target = "was ass-slapped by"
 
 	/// Use the number of required feet.
 	var/require_user_num_feet
@@ -46,15 +41,16 @@
 			return FALSE
 
 		// Special behavior for things like non-humans and if both sides are allowed
-		if(!(has_penis == TRUE) || !(user_require_penis_exposed && user_require_penis_unexposed))
-			if((user_require_penis_exposed) && has_penis == HAS_UNEXPOSED_GENITAL)
-				if(!silent)
-					to_chat(user, span_warning("Your penis need to be exposed."))
-				return FALSE
-			if((user_require_penis_unexposed) && has_penis == HAS_EXPOSED_GENITAL)
-				if(!silent)
-					to_chat(user, span_warning("Your penis need to be unexposed."))
-				return FALSE
+		if(!(user_require_penis_exposed && user_require_penis_unexposed))
+			if(!(has_penis == TRUE))
+				if((user_require_penis_exposed) && has_penis == HAS_UNEXPOSED_GENITAL)
+					if(!silent)
+						to_chat(user, span_warning("Your penis need to be exposed."))
+					return FALSE
+				if((user_require_penis_unexposed) && has_penis == HAS_EXPOSED_GENITAL)
+					if(!silent)
+						to_chat(user, span_warning("Your penis need to be unexposed."))
+					return FALSE
 
 	var/user_require_balls_exposed = !!(required_from_user_exposed & INTERACTION_REQUIRE_BALLS)
 	var/user_require_balls_unexposed = !!(required_from_user_unexposed & INTERACTION_REQUIRE_BALLS)
@@ -65,15 +61,16 @@
 				to_chat(user, span_warning("You don't have balls."))
 			return FALSE
 
-		if(!(has_balls == TRUE) || !(user_require_balls_exposed && user_require_balls_unexposed))
-			if((user_require_balls_exposed) && has_balls == HAS_UNEXPOSED_GENITAL)
-				if(!silent)
-					to_chat(user, span_warning("Your balls need to be exposed."))
-				return FALSE
-			if((user_require_balls_unexposed) && has_balls == HAS_EXPOSED_GENITAL)
-				if(!silent)
-					to_chat(user, span_warning("Your balls need to be unexposed."))
-				return FALSE
+		if(!(user_require_balls_exposed && user_require_balls_unexposed))
+			if(!(has_balls == TRUE))
+				if((user_require_balls_exposed) && has_balls == HAS_UNEXPOSED_GENITAL)
+					if(!silent)
+						to_chat(user, span_warning("Your balls need to be exposed."))
+					return FALSE
+				if((user_require_balls_unexposed) && has_balls == HAS_EXPOSED_GENITAL)
+					if(!silent)
+						to_chat(user, span_warning("Your balls need to be unexposed."))
+					return FALSE
 
 	var/user_require_anus_exposed = !!(required_from_user_exposed & INTERACTION_REQUIRE_ANUS)
 	var/user_require_anus_unexposed = !!(required_from_user_unexposed & INTERACTION_REQUIRE_ANUS)
@@ -84,15 +81,16 @@
 				to_chat(user, span_warning("You don't have an anus."))
 			return FALSE
 
-		if(!(has_anus == TRUE) || !(user_require_anus_exposed && user_require_anus_unexposed))
-			if(user_require_anus_exposed && has_anus == HAS_UNEXPOSED_GENITAL)
-				if(!silent)
-					to_chat(user, span_warning("Your anus needs to be exposed."))
-				return FALSE
-			if(user_require_anus_unexposed && has_anus == HAS_EXPOSED_GENITAL)
-				if(!silent)
-					to_chat(user, span_warning("Your anus needs to be unexposed."))
-				return FALSE
+		if(!(user_require_anus_exposed && user_require_anus_unexposed))
+			if(!(has_anus == TRUE))
+				if(user_require_anus_exposed && has_anus == HAS_UNEXPOSED_GENITAL)
+					if(!silent)
+						to_chat(user, span_warning("Your anus needs to be exposed."))
+					return FALSE
+				if(user_require_anus_unexposed && has_anus == HAS_EXPOSED_GENITAL)
+					if(!silent)
+						to_chat(user, span_warning("Your anus needs to be unexposed."))
+					return FALSE
 
 	var/user_require_vagina_exposed = !!(required_from_user_exposed & INTERACTION_REQUIRE_VAGINA)
 	var/user_require_vagina_unexposed = !!(required_from_user_unexposed & INTERACTION_REQUIRE_VAGINA)
@@ -103,15 +101,16 @@
 				to_chat(user, span_warning("You don't have a vagina."))
 			return FALSE
 
-		if(!(has_vagina == TRUE) || !(user_require_vagina_exposed && user_require_vagina_unexposed))
-			if(user_require_vagina_exposed && has_vagina == HAS_UNEXPOSED_GENITAL)
-				if(!silent)
-					to_chat(user, span_warning("Your vagina needs to be exposed."))
-				return FALSE
-			if(user_require_vagina_unexposed && has_vagina == HAS_EXPOSED_GENITAL)
-				if(!silent)
-					to_chat(user, span_warning("Your vagina needs to be unexposed."))
-				return FALSE
+		if(!(user_require_vagina_exposed && user_require_vagina_unexposed))
+			if(!(has_vagina == TRUE))
+				if(user_require_vagina_exposed && has_vagina == HAS_UNEXPOSED_GENITAL)
+					if(!silent)
+						to_chat(user, span_warning("Your vagina needs to be exposed."))
+					return FALSE
+				if(user_require_vagina_unexposed && has_vagina == HAS_EXPOSED_GENITAL)
+					if(!silent)
+						to_chat(user, span_warning("Your vagina needs to be unexposed."))
+					return FALSE
 
 	var/user_require_breasts_exposed = !!(required_from_user_exposed & INTERACTION_REQUIRE_BREASTS)
 	var/user_require_breasts_unexposed = !!(required_from_user_unexposed & INTERACTION_REQUIRE_BREASTS)
@@ -122,15 +121,16 @@
 				to_chat(user, span_warning("You don't have breasts."))
 			return FALSE
 
-		if(!(has_breasts == TRUE) || !(user_require_breasts_exposed && user_require_breasts_unexposed))
-			if(user_require_breasts_exposed && has_breasts == HAS_UNEXPOSED_GENITAL)
-				if(!silent)
-					to_chat(user, span_warning("Your breasts need to be exposed."))
-				return FALSE
-			if(user_require_breasts_unexposed && has_breasts == HAS_EXPOSED_GENITAL)
-				if(!silent)
-					to_chat(user, span_warning("Your breasts need to be unexposed."))
-				return FALSE
+		if(!(user_require_breasts_exposed && user_require_breasts_unexposed))
+			if(!(has_breasts == TRUE))
+				if(user_require_breasts_exposed && has_breasts == HAS_UNEXPOSED_GENITAL)
+					if(!silent)
+						to_chat(user, span_warning("Your breasts need to be exposed."))
+					return FALSE
+				if(user_require_breasts_unexposed && has_breasts == HAS_EXPOSED_GENITAL)
+					if(!silent)
+						to_chat(user, span_warning("Your breasts need to be unexposed."))
+					return FALSE
 
 	var/user_require_feet_exposed = !!(required_from_user_exposed & INTERACTION_REQUIRE_FEET)
 	var/user_require_feet_unexposed = !!(required_from_user_unexposed & INTERACTION_REQUIRE_FEET)
@@ -275,15 +275,16 @@
 				to_chat(target, span_warning("They don't have a penis."))
 			return FALSE
 
-		if(!(has_penis == TRUE) || !(target_require_penis_exposed && target_require_penis_unexposed))
-			if(target_require_penis_exposed && has_penis == HAS_UNEXPOSED_GENITAL)
-				if(!silent)
-					to_chat(target, span_warning("Their penis needs to be exposed."))
-				return FALSE
-			if(target_require_penis_unexposed && has_penis == HAS_EXPOSED_GENITAL)
-				if(!silent)
-					to_chat(target, span_warning("Their penis needs to be unexposed."))
-				return FALSE
+		if(!(target_require_penis_exposed && target_require_penis_unexposed))
+			if(!(has_penis == TRUE))
+				if(target_require_penis_exposed && has_penis == HAS_UNEXPOSED_GENITAL)
+					if(!silent)
+						to_chat(target, span_warning("Their penis needs to be exposed."))
+					return FALSE
+				if(target_require_penis_unexposed && has_penis == HAS_EXPOSED_GENITAL)
+					if(!silent)
+						to_chat(target, span_warning("Their penis needs to be unexposed."))
+					return FALSE
 
 	var/target_require_balls_exposed = !!(required_from_target_exposed & INTERACTION_REQUIRE_BALLS)
 	var/target_require_balls_unexposed = !!(required_from_target_unexposed & INTERACTION_REQUIRE_BALLS)
@@ -294,15 +295,16 @@
 				to_chat(target, span_warning("They don't have balls."))
 			return FALSE
 
-		if(!(has_balls == TRUE) || !(target_require_balls_exposed && target_require_balls_unexposed))
-			if(target_require_balls_exposed && has_balls == HAS_UNEXPOSED_GENITAL)
-				if(!silent)
-					to_chat(target, span_warning("Their balls need to be exposed."))
-				return FALSE
-			if(target_require_balls_unexposed && has_balls == HAS_EXPOSED_GENITAL)
-				if(!silent)
-					to_chat(target, span_warning("Their balls need to be unexposed."))
-				return FALSE
+		if(!(target_require_balls_exposed && target_require_balls_unexposed))
+			if(!(has_balls == TRUE))
+				if(target_require_balls_exposed && has_balls == HAS_UNEXPOSED_GENITAL)
+					if(!silent)
+						to_chat(target, span_warning("Their balls need to be exposed."))
+					return FALSE
+				if(target_require_balls_unexposed && has_balls == HAS_EXPOSED_GENITAL)
+					if(!silent)
+						to_chat(target, span_warning("Their balls need to be unexposed."))
+					return FALSE
 
 	var/target_require_anus_exposed = !!(required_from_target_exposed & INTERACTION_REQUIRE_ANUS)
 	var/target_require_anus_unexposed = !!(required_from_target_unexposed & INTERACTION_REQUIRE_ANUS)
@@ -313,15 +315,16 @@
 				to_chat(target, span_warning("They don't have an anus."))
 			return FALSE
 
-		if(!(has_anus == TRUE) || !(target_require_anus_exposed && target_require_anus_unexposed))
-			if(target_require_anus_exposed && has_anus == HAS_UNEXPOSED_GENITAL)
-				if(!silent)
-					to_chat(target, span_warning("Their anus needs to be exposed."))
-				return FALSE
-			if(target_require_anus_unexposed && has_anus == HAS_EXPOSED_GENITAL)
-				if(!silent)
-					to_chat(target, span_warning("Their anus needs to be unexposed."))
-				return FALSE
+		if(!(target_require_anus_exposed && target_require_anus_unexposed))
+			if(!(has_anus == TRUE))
+				if(target_require_anus_exposed && has_anus == HAS_UNEXPOSED_GENITAL)
+					if(!silent)
+						to_chat(target, span_warning("Their anus needs to be exposed."))
+					return FALSE
+				if(target_require_anus_unexposed && has_anus == HAS_EXPOSED_GENITAL)
+					if(!silent)
+						to_chat(target, span_warning("Their anus needs to be unexposed."))
+					return FALSE
 
 	var/target_require_vagina_exposed = !!(required_from_target_exposed & INTERACTION_REQUIRE_VAGINA)
 	var/target_require_vagina_unexposed = !!(required_from_target_unexposed & INTERACTION_REQUIRE_VAGINA)
@@ -332,15 +335,16 @@
 				to_chat(target, span_warning("They don't have a vagina."))
 			return FALSE
 
-		if(!(has_vagina == TRUE) || !(target_require_vagina_exposed && target_require_vagina_unexposed))
-			if(target_require_vagina_exposed && has_vagina == HAS_UNEXPOSED_GENITAL)
-				if(!silent)
-					to_chat(target, span_warning("Their vagina needs to be exposed."))
-				return FALSE
-			if(target_require_vagina_unexposed && has_vagina == HAS_EXPOSED_GENITAL)
-				if(!silent)
-					to_chat(target, span_warning("Their vagina needs to be unexposed."))
-				return FALSE
+		if(!(target_require_vagina_exposed && target_require_vagina_unexposed))
+			if(!(has_vagina == TRUE))
+				if(target_require_vagina_exposed && has_vagina == HAS_UNEXPOSED_GENITAL)
+					if(!silent)
+						to_chat(target, span_warning("Their vagina needs to be exposed."))
+					return FALSE
+				if(target_require_vagina_unexposed && has_vagina == HAS_EXPOSED_GENITAL)
+					if(!silent)
+						to_chat(target, span_warning("Their vagina needs to be unexposed."))
+					return FALSE
 
 	var/target_require_breasts_exposed = !!(required_from_target_exposed & INTERACTION_REQUIRE_BREASTS)
 	var/target_require_breasts_unexposed = !!(required_from_target_unexposed & INTERACTION_REQUIRE_BREASTS)
@@ -351,15 +355,16 @@
 				to_chat(target, span_warning("They don't have breasts."))
 			return FALSE
 
-		if(!(has_breasts == TRUE) || !(target_require_breasts_exposed && target_require_breasts_unexposed))
-			if(target_require_breasts_exposed && has_breasts == HAS_UNEXPOSED_GENITAL)
-				if(!silent)
-					to_chat(target, span_warning("Their breasts need to be exposed."))
-				return FALSE
-			if(target_require_breasts_unexposed && has_breasts == HAS_EXPOSED_GENITAL)
-				if(!silent)
-					to_chat(target, span_warning("Their breasts need to be unexposed."))
-				return FALSE
+		if(!(target_require_breasts_exposed && target_require_breasts_unexposed))
+			if(!(has_breasts == TRUE))
+				if(target_require_breasts_exposed && has_breasts == HAS_UNEXPOSED_GENITAL)
+					if(!silent)
+						to_chat(target, span_warning("Their breasts need to be exposed."))
+					return FALSE
+				if(target_require_breasts_unexposed && has_breasts == HAS_EXPOSED_GENITAL)
+					if(!silent)
+						to_chat(target, span_warning("Their breasts need to be unexposed."))
+					return FALSE
 
 	var/target_require_feet_exposed = !!(required_from_target_exposed & INTERACTION_REQUIRE_FEET)
 	var/target_require_feet_unexposed = !!(required_from_target_unexposed & INTERACTION_REQUIRE_FEET)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4051,6 +4051,7 @@
 #include "modular_sand\code\datums\interactions\interaction_datums\lewd\nipsuck.dm"
 #include "modular_sand\code\datums\interactions\interaction_datums\lewd\nuts.dm"
 #include "modular_sand\code\datums\interactions\interaction_datums\lewd\oral.dm"
+#include "modular_sand\code\datums\interactions\interaction_datums\lewd\slap.dm"
 #include "modular_sand\code\datums\interactions\interaction_datums\lewd\cursed\earfuck.dm"
 #include "modular_sand\code\datums\interactions\interaction_datums\lewd\cursed\eyefuck.dm"
 #include "modular_sand\code\datums\interactions\interaction_datums\lewd\self\breasts.dm"

--- a/tgui/packages/tgui/interfaces/MobInteraction.tsx
+++ b/tgui/packages/tgui/interfaces/MobInteraction.tsx
@@ -328,19 +328,33 @@ export const sortInteractions = (interactions, searchText = '', data) => {
           & interaction.interactionFlags) : true)),
     // Distance
     filter(interaction =>
-      interaction.maxDistance >= max_distance),
+      max_distance <= interaction.maxDistance),
     // User requirements
     filter(interaction =>
       interaction.required_from_user
         ? !!(required_from_user & interaction.required_from_user) : true),
-    // User requires exposed
-    filter(interaction => interaction.required_from_user_exposed
-      ? !!(required_from_user_exposed
-        & interaction.required_from_user_exposed) : true),
-    // User requires unexposed
-    filter(interaction => interaction.required_from_user_unexposed
-      ? !!(required_from_user_unexposed
-        & interaction.required_from_user_unexposed) : true),
+
+    filter(interaction => {
+      // User requires exposed
+      const exposed = !interaction.required_from_user_exposed
+      || ((interaction.required_from_user_exposed
+        & required_from_user_exposed)
+          === interaction.required_from_user_exposed);
+      // User requires unexposed
+      const unexposed = !interaction.required_from_user_unexposed
+      || ((interaction.required_from_user_unexposed
+        & required_from_user_unexposed)
+          === interaction.required_from_user_unexposed);
+
+      if (interaction.required_from_user_exposed
+        && interaction.required_from_user_unexposed) {
+        return exposed || unexposed;
+      }
+      else {
+        return exposed && unexposed;
+      }
+    }),
+
     // User required feet amount
     filter(interaction => interaction.user_num_feet
       ? (interaction.user_num_feet <= user_num_feet) : true),
@@ -348,14 +362,26 @@ export const sortInteractions = (interactions, searchText = '', data) => {
     filter(interaction => interaction.required_from_target
       ? !!(required_from_target
         & interaction.required_from_target) : true),
-    // Target requires exposed
-    filter(interaction => interaction.required_from_target_exposed
-      ? !!(required_from_target_exposed
-        & interaction.required_from_target_exposed) : true),
-    // Target requires unexposed
-    filter(interaction => interaction.required_from_target_unexposed
-      ? !!(required_from_target_unexposed
-        & interaction.required_from_target_unexposed) : true),
+    filter(interaction => {
+      // Target requires exposed
+      const exposed = !interaction.required_from_target_exposed
+          || ((interaction.required_from_target_exposed
+            & required_from_target_exposed)
+              === interaction.required_from_target_exposed);
+      // Target requires unexposed
+      const unexposed = !interaction.required_from_target_unexposed
+          || ((interaction.required_from_target_unexposed
+            & required_from_target_unexposed)
+              === interaction.required_from_target_unexposed);
+
+      if (interaction.required_from_target_exposed
+            && interaction.required_from_target_unexposed) {
+        return exposed || unexposed;
+      }
+      else {
+        return exposed && unexposed;
+      }
+    }),
     // Target required feet amount
     filter(interaction => interaction.target_num_feet
       ? (interaction.target_num_feet <= target_num_feet) : true),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, adds unit tests and some other stuff.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
fix: Interactions that allow both exposed and unexposed can be done once again.
refactor: "Slap their ass" has been moved off of /datum/interaction into its own interaction, using basetypes for anything is now forbidden.
code: There are now unit tests for creating interactions incorrectly.
qol: Max distance check has been flipped to make more sense.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
