### PR TITLE
Fixes text effects for runechat.

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -124,15 +124,21 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	return "[say_mod(input, message_mode)][spanned ? ", \"[spanned]\"" : ""]"
 	// Citadel edit [spanned ? ", \"[spanned]\"" : ""]"
 
-/// Converts specific characters, like +, |, and _ to formatted output.
+/// Transforms the speech emphasis mods from [/atom/movable/proc/say_emphasis] into the appropriate HTML tags. Includes escaping.
+#define ENCODE_HTML_EMPHASIS(input, char, html, varname) \
+	var/static/regex/##varname = regex("(?<!\\\\)[char](.+?)(?<!\\\\)[char]", "g");\
+	input = varname.Replace_char(input, "<[html]>$1</[html]>&#8203;") //zero-widht space to force maptext to respect closing tags.
+
+/// Scans the input sentence for speech emphasis modifiers, notably |italics|, +bold+, and _underline_ -mothblocks
 /atom/movable/proc/say_emphasis(input)
-	var/static/regex/italics = regex(@"\|((?=\S)[\w\W]*?(?<=\S))\|", "g")
-	input = italics.Replace_char(input, "<i>$1</i>")
-	var/static/regex/bold = regex(@"\+((?=\S)[\w\W]*?(?<=\S))\+", "g")
-	input = bold.Replace_char(input, "<b>$1</b>")
-	var/static/regex/underline = regex(@"_((?=\S)[\w\W]*?(?<=\S))_", "g")
-	input = underline.Replace_char(input, "<u>$1</u>")
+	ENCODE_HTML_EMPHASIS(input, "\\|", "i", italics)
+	ENCODE_HTML_EMPHASIS(input, "\\+", "b", bold)
+	ENCODE_HTML_EMPHASIS(input, "_", "u", underline)
+	var/static/regex/remove_escape_backlashes = regex("\\\\(_|\\+|\\|)", "g") // Removes backslashes used to escape text modification.
+	input = remove_escape_backlashes.Replace_char(input, "$1")
 	return input
+
+#undef ENCODE_HTML_EMPHASIS
 
 /// Quirky citadel proc for our custom sayverbs to strip the verb out. Snowflakey as hell, say rewrite 3.0 when?
 /atom/movable/proc/quoteless_say_quote(input, list/spans = list(speech_span), message_mode)

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -1,3 +1,4 @@
+@You can wrap portions of your messages with |, + or _ characters to <i>italicize</i>, <b>embolden</b> or <u>underline</u> them respectively. You can also escape these modifiers by adding backslashes before the mentioned characters.
 Where the space map levels connect is randomized every round, but are otherwise kept consistent within rounds. Remember that they are not necessarily bidirectional!
 You can catch thrown items by toggling on your throw mode with an empty hand active.
 To crack the safe in the vault, have a stethoscope in one of your hands and fiddle with the tumbler or use a couple C4s on it. Remember the latter option may result in the contents of the safe becoming non-existant.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This stuff has been cramping 100% heavy roleplay style for too long.

Somehow, the way maptext is formatted* seems to break tag ends found around a line break. This usually happens when a space with width is found by the end of the line, and I don't recall ever encountering the issue otherwise.
Apparently, I've also found out that concatenating two spaces, regardless of width, seems to fix the issue just fine, and that brings in the solution to this whole pedantic problem: a zero-width space at the end of the closing tag.

*That's handled behind the curtains by the engine, so I can only throw wild guesses to why it happens.

Oh, by the by, I've also changed the tip about text modifiers I've made over a year ago. It was too confusing to read.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Comparison between before and after, and how it looks in the UI.
![image](https://github.com/Sandstorm-Station/Sandstorm-Station-13/assets/43283559/fa557974-f44b-4b9c-a3d4-5dac033b52e4)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
***Port of [tgstation#81170](https://github.com/tgstation/tgstation/pull/81170)***
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
fix: Fixed text effects for runechat messages (the stuff enclosed in +, | and _ characters).
spellcheck: Improved the tip for say/text effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
