### PR TITLE
Makes lewd sounds appear on the top-left settings menu and defaults long strip menu

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -200,7 +200,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	///Should we be in the widescreen mode set by the config?
 	var/widescreenpref = TRUE
 	///Strip menu style
-	var/long_strip_menu = FALSE
+	var/long_strip_menu = TRUE
 	///What size should pixels be displayed as? 0 is strech to fit
 	var/pixel_size = 0
 	///What scaling method should we use?
@@ -1338,7 +1338,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "<table><tr><td width='340px' height='300px' valign='top'>"
 					dat += "<h2>Fetish content prefs</h2>"
 					dat += "<b>Allow Lewd Verbs:</b> <a href='?_src_=prefs;preference=verb_consent'>[(toggles & VERB_CONSENT) ? "Yes":"No"]</a><br>" // Skyrat - ERP Mechanic Addition
-					dat += "<b>Mute Lewd Verb Sounds:</b> <a href='?_src_=prefs;preference=mute_lewd_verb_sounds'>[(toggles & LEWD_VERB_SOUNDS) ? "Yes":"No"]</a><br>" // Sandstorm - ERP Mechanic Addition
+					dat += "<b>Lewd Verb Sounds:</b> <a href='?_src_=prefs;preference=lewd_verb_sounds'>[(toggles & LEWD_VERB_SOUNDS) ? "Yes":"No"]</a><br>" // Sandstorm - ERP Mechanic Addition
 					dat += "<b>Arousal:</b><a href='?_src_=prefs;preference=arousable'>[arousable == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 					dat += "<b>Genital examine text</b>:<a href='?_src_=prefs;preference=genital_examine'>[(cit_toggles & GENITAL_EXAMINE) ? "Enabled" : "Disabled"]</a><BR>"
 					dat += "<b>Vore examine text</b>:<a href='?_src_=prefs;preference=vore_examine'>[(cit_toggles & VORE_EXAMINE) ? "Enabled" : "Disabled"]</a><BR>"
@@ -3281,7 +3281,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("verb_consent") // Skyrat - ERP Mechanic Addition
 					toggles ^= VERB_CONSENT // Skyrat - ERP Mechanic Addition
 
-				if("mute_lewd_verb_sounds") // Skyrat - ERP Mechanic Addition
+				if("lewd_verb_sounds") // Skyrat - ERP Mechanic Addition
 					toggles ^= LEWD_VERB_SOUNDS // Skyrat - ERP Mechanic Addition
 
 				if("persistent_scars")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	59
+#define SAVEFILE_VERSION_MAX	59.1
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn

--- a/modular_sand/code/datums/components/interaction_menu_granter.dm
+++ b/modular_sand/code/datums/components/interaction_menu_granter.dm
@@ -401,7 +401,7 @@
 
 	//Getting preferences
 		.["verb_consent"] = 		!!CHECK_BITFIELD(prefs.toggles, VERB_CONSENT)
-		.["lewd_verb_sounds"] = 	!CHECK_BITFIELD(prefs.toggles, LEWD_VERB_SOUNDS)
+		.["lewd_verb_sounds"] = 	!!CHECK_BITFIELD(prefs.toggles, LEWD_VERB_SOUNDS)
 		.["arousable"] = 			prefs.arousable
 		.["genital_examine"] = 		!!CHECK_BITFIELD(prefs.cit_toggles, GENITAL_EXAMINE)
 		.["vore_examine"] = 		!!CHECK_BITFIELD(prefs.cit_toggles, VORE_EXAMINE)

--- a/modular_sand/code/datums/interactions/lewd_definitions.dm
+++ b/modular_sand/code/datums/interactions/lewd_definitions.dm
@@ -8,7 +8,7 @@
 /proc/playlewdinteractionsound(turf/turf_source, soundin, vol as num, vary, extrarange as num, frequency, falloff, channel = 0, pressure_affected = TRUE, sound/S, envwet = -10000, envdry = 0, manual_x, manual_y, list/ignored_mobs)
 	var/list/hearing_mobs
 	for(var/mob/H in get_hearers_in_view(4, turf_source))
-		if(!H.client || (H.client.prefs.toggles & LEWD_VERB_SOUNDS))
+		if(!H.client || !(H.client.prefs.toggles & LEWD_VERB_SOUNDS))
 			continue
 		LAZYADD(hearing_mobs, H)
 	if(ignored_mobs?.len)

--- a/modular_sand/code/modules/client/preferences_savefile.dm
+++ b/modular_sand/code/modules/client/preferences_savefile.dm
@@ -16,6 +16,13 @@
 		if(CHECK_BITFIELD(toggles, SOUND_BARK))
 			DISABLE_BITFIELD(toggles, SOUND_BARK)
 			ENABLE_BITFIELD(toggles, VERB_CONSENT)
+
+	if(current_version < 59.1)
+		// Just invert it, now it's a switch to see if you want it on, rather than off.
+		TOGGLE_BITFIELD(toggles, LEWD_VERB_SOUNDS)
+
+		// It may not be a default on cit, but this is meant to be default here at least.
+		long_strip_menu = TRUE
 	. = ..()
 
 /datum/preferences/save_preferences(bypass_cooldown, silent)

--- a/modular_sand/code/modules/client/preferences_toggles.dm
+++ b/modular_sand/code/modules/client/preferences_toggles.dm
@@ -1,0 +1,13 @@
+TOGGLE_CHECKBOX(/datum/verbs/menu/Settings/Sound, toggle_lewd_sounds)()
+	set name = "Hear/Silence Lewd Verb Sounds"
+	set category = "Preferences"
+	set desc = "Hear Lewd Verb Sounds From Interactions"
+	usr.client.prefs.toggles ^= LEWD_VERB_SOUNDS
+	usr.client.prefs.save_preferences()
+	if(usr.client.prefs.toggles & LEWD_VERB_SOUNDS)
+		to_chat(usr, "You will now hear lewd verb sounds.")
+	else
+		to_chat(usr, "You will no longer hear lewd verb sounds")
+	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Hearing Lewd Verb Sounds", "[usr.client.prefs.toggles & LEWD_VERB_SOUNDS ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/verbs/menu/Settings/Sound/toggle_lewd_sounds/Get_checked(client/C)
+	return C.prefs.toggles & LEWD_VERB_SOUNDS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4187,6 +4187,7 @@
 #include "modular_sand\code\modules\client\client_procs.dm"
 #include "modular_sand\code\modules\client\preferences.dm"
 #include "modular_sand\code\modules\client\preferences_savefile.dm"
+#include "modular_sand\code\modules\client\preferences_toggles.dm"
 #include "modular_sand\code\modules\client\loadout\_security.dm"
 #include "modular_sand\code\modules\client\loadout\accessories.dm"
 #include "modular_sand\code\modules\client\loadout\backpack.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a good idea to have preferences to be about enabling something, and not disabling something.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Changelog
:cl:
add: Top-left menu now has lewd sounds toggle.
tweak: The preference for lewd sounds is now about activating them, not muting. (your preferences have been automatically flipped to account for this)
tweak: Long strip menu is meant to be default on for sandstorm, and so it has been set so.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
